### PR TITLE
Rydde opp i JSON-oppsett

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     compile("io.ktor:ktor-client-apache:$ktorVersion")
     compile("io.ktor:ktor-client-json:$ktorVersion")
     compile("io.ktor:ktor-client-serialization-jvm:$ktorVersion")
-    compile("io.ktor:ktor-client-gson:$ktorVersion")
+    compile("io.ktor:ktor-client-jackson:$ktorVersion")
     compile("ch.qos.logback:logback-classic:$logbackVersion")
     compile("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
     compile("io.ktor:ktor-client-logging:$ktorVersion")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/Brukernotifikasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/Brukernotifikasjon.kt
@@ -1,13 +1,13 @@
 package no.nav.personbruker.dittnav.api.brukernotifikasjon
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 data class Brukernotifikasjon(
-    val produsent: String,
-    val eventTidspunkt: LocalDateTime,
-    val eventId: String,
-    val tekst: String,
-    val link: String,
-    val sistOppdatert: LocalDateTime,
-    val type: BrukernotifikasjonType
+        val produsent: String,
+        val eventTidspunkt: ZonedDateTime,
+        val eventId: String,
+        val tekst: String,
+        val link: String,
+        val sistOppdatert: ZonedDateTime,
+        val type: BrukernotifikasjonType
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/HttpClientBuilder.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/HttpClientBuilder.kt
@@ -2,7 +2,6 @@ package no.nav.personbruker.dittnav.api.config
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.apache.Apache
-import io.ktor.client.features.json.GsonSerializer
 import io.ktor.client.features.json.JsonFeature
 
 object HttpClientBuilder {
@@ -10,9 +9,10 @@ object HttpClientBuilder {
     fun build(): HttpClient {
         return HttpClient(Apache) {
             install(JsonFeature) {
-                serializer = GsonSerializer()
+                serializer = buildJsonSerializer()
             }
         }
     }
+
 
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/JsonConfig.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/JsonConfig.kt
@@ -1,0 +1,17 @@
+package no.nav.personbruker.dittnav.api.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import io.ktor.client.features.json.JacksonSerializer
+
+fun buildJsonSerializer(): JacksonSerializer {
+    return JacksonSerializer {
+        enableDittNavJsonConfig()
+    }
+}
+
+fun ObjectMapper.enableDittNavJsonConfig() {
+    registerModule(JavaTimeModule())
+    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -1,6 +1,5 @@
 package no.nav.personbruker.dittnav.api.config
 
-import com.fasterxml.jackson.databind.SerializationFeature
 import io.ktor.application.Application
 import io.ktor.application.install
 import io.ktor.auth.Authentication
@@ -42,7 +41,7 @@ fun Application.mainModule() {
 
     install(ContentNegotiation) {
         jackson {
-            enable(SerializationFeature.INDENT_OUTPUT)
+            enableDittNavJsonConfig()
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/informasjon/Informasjon.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/informasjon/Informasjon.kt
@@ -1,15 +1,16 @@
 package no.nav.personbruker.dittnav.api.informasjon
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 data class Informasjon(
         val produsent: String,
-        val eventTidspunkt: LocalDateTime,
+        val eventTidspunkt: ZonedDateTime,
         val aktorId: String,
         val eventId: String,
         val dokumentId: String,
         val tekst: String,
         val link: String,
         val sikkerhetsnivaa: Int,
-        val sistOppdatert: LocalDateTime
+        val sistOppdatert: ZonedDateTime,
+        val aktiv: Boolean
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/Oppgave.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/Oppgave.kt
@@ -1,16 +1,16 @@
 package no.nav.personbruker.dittnav.api.oppgave
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 data class Oppgave(
         val produsent: String,
-        val eventTidspunkt: LocalDateTime,
+        val eventTidspunkt: ZonedDateTime,
         val aktorId: String,
         val eventId: String,
         val dokumentId: String,
         val tekst: String,
         val link: String,
         val sikkerhetsnivaa: Int,
-        val sistOppdatert: LocalDateTime
+        val sistOppdatert: ZonedDateTime,
+        val aktiv: Boolean
 )
-

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotfikasjonObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotfikasjonObjectMother.kt
@@ -1,32 +1,31 @@
 package no.nav.personbruker.dittnav.api.brukernotifikasjon
 
-import no.nav.personbruker.dittnav.api.informasjon.Informasjon
-import java.time.LocalDateTime
 import java.time.ZoneId
+import java.time.ZonedDateTime
 
 object BrukernotfikasjonObjectMother {
 
     fun createInformasjonsBrukernotifikasjon(eventId: String): Brukernotifikasjon {
         return Brukernotifikasjon(
-            produsent = "DittNav",
-            eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
-            eventId = eventId,
-            tekst = "Dette er informasjon til brukeren",
-            link = "https://nav.no/systemX/",
-            sistOppdatert = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
-            type = BrukernotifikasjonType.INFORMASJON
+                produsent = "DittNav",
+                eventTidspunkt = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                eventId = eventId,
+                tekst = "Dette er informasjon til brukeren",
+                link = "https://nav.no/systemX/",
+                sistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                type = BrukernotifikasjonType.INFORMASJON
         )
     }
 
     fun createOppgaveBrukernotifikasjon(eventId: String): Brukernotifikasjon {
         return Brukernotifikasjon(
-            produsent = "DittNav",
-            eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
-            eventId = eventId,
-            tekst = "Dette er informasjon til brukeren",
-            link = "https://nav.no/systemX/",
-            sistOppdatert = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
-            type = BrukernotifikasjonType.OPPGAVE
+                produsent = "DittNav",
+                eventTidspunkt = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                eventId = eventId,
+                tekst = "Dette er informasjon til brukeren",
+                link = "https://nav.no/systemX/",
+                sistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                type = BrukernotifikasjonType.OPPGAVE
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/informasjon/InformasjonObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/informasjon/InformasjonObjectMother.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.api.informasjon
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.time.ZoneId
 
 object InformasjonObjectMother {
@@ -8,14 +8,15 @@ object InformasjonObjectMother {
     fun createInformasjon(eventId: String, aktorId: String): Informasjon {
         return Informasjon(
                 produsent = "DittNav",
-                eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
+                eventTidspunkt = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
                 aktorId = aktorId,
                 eventId = eventId,
                 dokumentId = "Dok123",
                 tekst = "Dette er informasjon til brukeren",
                 link = "https://nav.no/systemX/",
                 sikkerhetsnivaa = 4,
-                sistOppdatert = LocalDateTime.now(ZoneId.of("Europe/Oslo"))
+                sistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                aktiv = true
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveObjectMother.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.api.oppgave
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.time.ZoneId
 
 object OppgaveObjectMother {
@@ -8,14 +8,15 @@ object OppgaveObjectMother {
     fun createOppgave(eventId: String, aktorId: String): Oppgave {
         return Oppgave(
                 produsent = "DittNav",
-                eventTidspunkt = LocalDateTime.now(ZoneId.of("Europe/Oslo")),
+                eventTidspunkt = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
                 aktorId = aktorId,
                 eventId = eventId,
                 dokumentId = "Dok123",
                 tekst = "Dette er en oppgave til brukeren",
                 link = "https://nav.no/systemX/",
                 sikkerhetsnivaa = 4,
-                sistOppdatert = LocalDateTime.now(ZoneId.of("Europe/Oslo"))
+                sistOppdatert = ZonedDateTime.now(ZoneId.of("Europe/Oslo")),
+                aktiv = true
         )
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveTransformerTest.kt
@@ -5,7 +5,6 @@ import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be`
 import org.junit.jupiter.api.Test
 
-
 class OppgaveTransformerTest {
 
     @Test
@@ -19,7 +18,7 @@ class OppgaveTransformerTest {
         brukernotifikasjon.eventTidspunkt `should be` oppgave1.eventTidspunkt
         brukernotifikasjon.eventId `should be equal to` oppgave1.eventId
         brukernotifikasjon.tekst `should be equal to` oppgave1.tekst
-        brukernotifikasjon.link `should be equal to`oppgave1.link
+        brukernotifikasjon.link `should be equal to` oppgave1.link
         brukernotifikasjon.sistOppdatert `should be` oppgave1.sistOppdatert
         brukernotifikasjon.type `should be` BrukernotifikasjonType.OPPGAVE
     }


### PR DESCRIPTION
* Har fjernet GSON, og konfigurert Jackson til å være satt opp på samme måte som det event-handler er.
* Har laget hjelpemetoder som gjør at Jackson sin object-mapper kun trengs å konfigureres ett sted, og lett kan tas i bruke flere steder med samme konfig.
* Innført samme datoformat som det event-handler bruker, så er det opp til frontend hvordan dette skal vises.
* Lagt til det nye feltet fra event-handler som angir om et event er aktivt eller ikke.

PB-283. Rydde opp i JSON-oppsett