### PR TITLE
Feature/hent token fra context

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.api.beskjed
 
 import io.ktor.client.HttpClient
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.get
 import java.net.URL
 
@@ -10,7 +11,7 @@ class BeskjedConsumer(
         private val completePathToEndpoint: URL = URL("$dittNAVEventsBaseURL/fetch/beskjed")
 ) {
 
-    suspend fun getExternalEvents(token: String): List<Beskjed> {
-        return client.get(completePathToEndpoint, token)
+    suspend fun getExternalEvents(innloggetBruker: InnloggetBruker): List<Beskjed> {
+        return client.get(completePathToEndpoint, innloggetBruker)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedService.kt
@@ -2,15 +2,16 @@ package no.nav.personbruker.dittnav.api.beskjed
 
 import io.ktor.util.error
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.Brukernotifikasjon
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import org.slf4j.LoggerFactory
 
 class BeskjedService(private val beskjedConsumer: BeskjedConsumer) {
 
     private val log = LoggerFactory.getLogger(BeskjedService::class.java)
 
-    suspend fun getBeskjedEventsAsBrukernotifikasjoner(token: String): List<Brukernotifikasjon> {
+    suspend fun getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
-            beskjedConsumer.getExternalEvents(token).map { beskjed ->
+            beskjedConsumer.getExternalEvents(innloggetBruker).map { beskjed ->
                 toBrukernotifikasjon(beskjed)
             }
         } catch (exception: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonService.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.brukernotifikasjon
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.innboks.InnboksService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
 
@@ -12,25 +13,25 @@ class BrukernotifikasjonService(
         private val innboksService: InnboksService
 ) {
 
-    suspend fun getBrukernotifikasjoner(token: String): List<Brukernotifikasjon> {
+    suspend fun getBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return coroutineScope {
-            val oppgaver = async { getOppgaver(token) }
-            val beskjed = async { getBeskjed(token) }
-            val innboks = async { getInnboks(token) }
+            val oppgaver = async { getOppgaver(innloggetBruker) }
+            val beskjed = async { getBeskjed(innloggetBruker) }
+            val innboks = async { getInnboks(innloggetBruker) }
 
             oppgaver.await() + beskjed.await() + innboks.await()
         }
     }
 
-    private suspend fun getOppgaver(token: String): List<Brukernotifikasjon> {
-        return oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(token)
+    private suspend fun getOppgaver(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
+        return oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker)
     }
 
-    private suspend fun getBeskjed(token: String): List<Brukernotifikasjon> {
-        return beskjedService.getBeskjedEventsAsBrukernotifikasjoner(token)
+    private suspend fun getBeskjed(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
+        return beskjedService.getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker)
     }
 
-    private suspend fun getInnboks(token: String): List<Brukernotifikasjon> {
-        return innboksService.getInnboksEventsAsBrukernotifikasjoner(token)
+    private suspend fun getInnboks(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
+        return innboksService.getInnboksEventsAsBrukernotifikasjoner(innloggetBruker)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -4,11 +4,11 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.common.brukerToken
+import no.nav.personbruker.dittnav.api.common.hentInnloggetBruker
 
 fun Route.brukernotifikasjoner(brukernotifikasjonService: BrukernotifikasjonService) {
 
     get("/brukernotifikasjoner") {
-        call.respond(brukernotifikasjonService.getBrukernotifikasjoner(brukerToken))
+        call.respond(brukernotifikasjonService.getBrukernotifikasjoner(hentInnloggetBruker()))
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
@@ -1,0 +1,19 @@
+package no.nav.personbruker.dittnav.api.common
+
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+
+class InnloggetBruker(val principal: OIDCValidationContextPrincipal?) {
+
+    fun getBearerToken(): String {
+        return "Bearer " + getTokenAsString()
+    }
+
+    fun getTokenAsString(): String {
+        val token = principal?.context?.firstValidToken?.get()?.tokenAsString
+        if (token == null) {
+            throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje..")
+        } else {
+            return token
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/apiUtil.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/apiUtil.kt
@@ -2,24 +2,16 @@ package no.nav.personbruker.dittnav.api.common
 
 import io.ktor.application.ApplicationCall
 import io.ktor.application.call
-import io.ktor.http.HttpHeaders
+import io.ktor.auth.authentication
 import io.ktor.util.pipeline.PipelineContext
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
 
-fun PipelineContext<Unit, ApplicationCall>.extractTokenFromRequest(): String {
-    var authToken = getTokenFromHeader()
-    if (authToken == null) {
-        authToken = getTokenFromCookie()
-    }
-    if (authToken == null) {
+fun PipelineContext<Unit, ApplicationCall>.hentInnloggetBruker(): InnloggetBruker {
+
+    val innloggetBruker = InnloggetBruker(call.authentication.principal<OIDCValidationContextPrincipal>())
+
+    if (innloggetBruker.principal == null) {
         throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
     }
-    return authToken
+    return innloggetBruker
 }
-
-private fun PipelineContext<Unit, ApplicationCall>.getTokenFromHeader() =
-        call.request.headers[HttpHeaders.Authorization]?.replace("Bearer ", "")
-
-fun PipelineContext<Unit, ApplicationCall>.getTokenFromCookie() =
-        call.request.cookies["selvbetjening-idtoken"]
-
-val PipelineContext<Unit, ApplicationCall>.brukerToken: String get() = extractTokenFromRequest()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -8,12 +8,13 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import java.net.URL
 
-suspend inline fun <reified T> HttpClient.get(url: URL, token: String): T = withContext(Dispatchers.IO) {
+suspend inline fun <reified T> HttpClient.get(url: URL, innloggetBruker: InnloggetBruker): T = withContext(Dispatchers.IO) {
     request<T> {
         url(url)
         method = HttpMethod.Get
-        header(HttpHeaders.Authorization, "Bearer $token")
+        header(HttpHeaders.Authorization, innloggetBruker.getBearerToken())
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.api.innboks
 
 import io.ktor.client.HttpClient
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.get
 import java.net.URL
 
@@ -10,7 +11,7 @@ class InnboksConsumer(
         private val completePathToEndpoint: URL = URL("$dittNAVEventsBaseURL/fetch/innboks")
 ) {
 
-    suspend fun getExternalEvents(token: String): List<Innboks> {
-        return client.get(completePathToEndpoint, token)
+    suspend fun getExternalEvents(innloggetBruker: InnloggetBruker): List<Innboks> {
+        return client.get(completePathToEndpoint, innloggetBruker)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksService.kt
@@ -2,14 +2,15 @@ package no.nav.personbruker.dittnav.api.innboks
 
 import io.ktor.util.error
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.Brukernotifikasjon
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import org.slf4j.LoggerFactory
 
 class InnboksService (private val innboksConsumer: InnboksConsumer) {
     private val log = LoggerFactory.getLogger(InnboksService::class.java)
 
-    suspend fun getInnboksEventsAsBrukernotifikasjoner(token: String): List<Brukernotifikasjon> {
+    suspend fun getInnboksEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
-            innboksConsumer.getExternalEvents(token).map { innboks ->
+            innboksConsumer.getExternalEvents(innloggetBruker).map { innboks ->
                 toBrukernotifikasjon(innboks)
             }
         } catch (exception: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/LegacyConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/LegacyConsumer.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.legacy
 import io.ktor.client.HttpClient
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.HttpStatusCode
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.get
 import org.slf4j.LoggerFactory
 import java.net.URL
@@ -11,10 +12,10 @@ class LegacyConsumer(private val httpClient: HttpClient, private val dittNAVLega
 
     private val log = LoggerFactory.getLogger(LegacyConsumer::class.java)
 
-    suspend fun getLegacyContent(path: String, token: String): HttpResponse {
+    suspend fun getLegacyContent(path: String, innloggetBruker: InnloggetBruker): HttpResponse {
         val endpoint = URL("$dittNAVLegacyBaseURL$path")
         log.info("Skal hente fra: $endpoint")
-        val response: HttpResponse = httpClient.get(endpoint, token)
+        val response: HttpResponse = httpClient.get(endpoint, innloggetBruker)
         if (response.status != HttpStatusCode.OK) {
             log.warn("Error mot $dittNAVLegacyBaseURL$path: ${response.status.value} ${response.status.description}")
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -7,7 +7,7 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.personbruker.dittnav.api.common.extractTokenFromRequest
+import no.nav.personbruker.dittnav.api.common.hentInnloggetBruker
 
 fun Route.legacyApi(legacyConsumer: LegacyConsumer) {
 
@@ -50,6 +50,6 @@ fun Route.legacyApi(legacyConsumer: LegacyConsumer) {
 }
 
 private suspend fun PipelineContext<Unit, ApplicationCall>.hentRaattFraLegacyApiOgReturnerResponsen(consumer: LegacyConsumer, path: String) {
-    val response = consumer.getLegacyContent(path, extractTokenFromRequest())
+    val response = consumer.getLegacyContent(path, hentInnloggetBruker())
     call.respond(response.status, response.readBytes())
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumer.kt
@@ -1,6 +1,7 @@
 package no.nav.personbruker.dittnav.api.oppgave
 
 import io.ktor.client.HttpClient
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.get
 import java.net.URL
 
@@ -10,7 +11,7 @@ class OppgaveConsumer(
     private val completePathToEndpoint: URL = URL("$dittNAVEventsBaseURL/fetch/oppgave")
 ) {
 
-    suspend fun getExternalEvents(token: String): List<Oppgave> {
-        return client.get(completePathToEndpoint, token)
+    suspend fun getExternalEvents(innloggetBruker: InnloggetBruker): List<Oppgave> {
+        return client.get(completePathToEndpoint, innloggetBruker)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveService.kt
@@ -2,15 +2,16 @@ package no.nav.personbruker.dittnav.api.oppgave
 
 import io.ktor.util.error
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.Brukernotifikasjon
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import org.slf4j.LoggerFactory
 
 class OppgaveService(private val oppgaveConsumer: OppgaveConsumer) {
 
     private val log = LoggerFactory.getLogger(OppgaveService::class.java)
 
-    suspend fun getOppgaveEventsAsBrukernotifikasjoner(token: String): List<Brukernotifikasjon> {
+    suspend fun getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
-            oppgaveConsumer.getExternalEvents(token).map { oppgave ->
+            oppgaveConsumer.getExternalEvents(innloggetBruker).map { oppgave ->
                  toBrukernotifikasjon(oppgave)
             }
         } catch (exception: Exception) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -21,7 +21,7 @@ import java.net.URL
 
 class BeskjedConsumerTest {
 
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call information endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.Test
 import java.net.URL
 
 class BeskjedConsumerTest {
+
+    val innloggetBruker = createInnloggetBruker()
 
     @Test
     fun `should call information endpoint on event handler`() {
@@ -39,7 +42,7 @@ class BeskjedConsumerTest {
         val beskjedConsumer = BeskjedConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            beskjedConsumer.getExternalEvents("1234") `should equal` emptyList()
+            beskjedConsumer.getExternalEvents(innloggetBruker) `should equal` emptyList()
         }
     }
 
@@ -66,9 +69,9 @@ class BeskjedConsumerTest {
         val beskjedConsumer = BeskjedConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            beskjedConsumer.getExternalEvents("1234").size `should be equal to` 1
-            beskjedConsumer.getExternalEvents("1234")[0].tekst `should be equal to` beskjedObject.tekst
-            beskjedConsumer.getExternalEvents("1234")[0].fodselsnummer `should be equal to` beskjedObject.fodselsnummer
+            beskjedConsumer.getExternalEvents(innloggetBruker).size `should be equal to` 1
+            beskjedConsumer.getExternalEvents(innloggetBruker)[0].tekst `should be equal to` beskjedObject.tekst
+            beskjedConsumer.getExternalEvents(innloggetBruker)[0].fodselsnummer `should be equal to` beskjedObject.fodselsnummer
         }
 
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
@@ -3,14 +3,14 @@ package no.nav.personbruker.dittnav.api.beskjed
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 
 class BeskjedServiceTest {
 
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     val beskjedConsumer = mockk<BeskjedConsumer>()
     val beskjedService = BeskjedService(beskjedConsumer)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
@@ -3,11 +3,14 @@ package no.nav.personbruker.dittnav.api.beskjed
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
 
 class BeskjedServiceTest {
+
+    val innloggetBruker = createInnloggetBruker()
 
     val beskjedConsumer = mockk<BeskjedConsumer>()
     val beskjedService = BeskjedService(beskjedConsumer)
@@ -16,10 +19,10 @@ class BeskjedServiceTest {
 
     @Test
     fun `should return list of Brukernotifikasjoner when Events are received`() {
-        coEvery { beskjedConsumer.getExternalEvents("1234") } returns listOf(beskjed1, beskjed2)
+        coEvery { beskjedConsumer.getExternalEvents(innloggetBruker) } returns listOf(beskjed1, beskjed2)
 
         runBlocking {
-            val brukernotifikasjonListe = beskjedService.getBeskjedEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = beskjedService.getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 2
         }
 
@@ -27,10 +30,10 @@ class BeskjedServiceTest {
 
     @Test
     fun `should return empty list when Exception is thrown`() {
-        coEvery { beskjedConsumer.getExternalEvents("1234") } throws Exception("error")
+        coEvery { beskjedConsumer.getExternalEvents(innloggetBruker) } throws Exception("error")
 
         runBlocking {
-            val brukernotifikasjonListe = beskjedService.getBeskjedEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = beskjedService.getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 0
         }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import no.nav.personbruker.dittnav.api.innboks.InnboksService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
 import org.amshove.kluent.`should be equal to`
@@ -21,13 +22,15 @@ class BrukernotifikasjonServiceTest {
     val oppgave1 = BrukernotfikasjonObjectMother.createOppgaveBrukernotifikasjon("3")
     val innboks1 = BrukernotfikasjonObjectMother.createInnboksBrukernotifikasjon("4")
 
+    val innloggetBruker = createInnloggetBruker()
+
     @Test
     fun `should receive brukernotfikasjoner of type Beskjed and Oppgave`() {
-        coEvery { oppgaveService.getOppgaveEventsAsBrukernotifikasjoner("1234") } returns listOf(oppgave1)
-        coEvery { beskjedService.getBeskjedEventsAsBrukernotifikasjoner("1234") } returns listOf(beskjed1, beskjed2)
-        coEvery { innboksService.getInnboksEventsAsBrukernotifikasjoner("1234") } returns listOf(innboks1)
+        coEvery { oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker) } returns listOf(oppgave1)
+        coEvery { beskjedService.getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker) } returns listOf(beskjed1, beskjed2)
+        coEvery { innboksService.getInnboksEventsAsBrukernotifikasjoner(innloggetBruker) } returns listOf(innboks1)
 
-        val brukernotifikasjoner = runBlocking { brukernotifikasjonService.getBrukernotifikasjoner("1234") }
+        val brukernotifikasjoner = runBlocking { brukernotifikasjonService.getBrukernotifikasjoner(innloggetBruker) }
         brukernotifikasjoner.size `should be equal to` 4
         brukernotifikasjoner
             .filter { notifikasjon -> notifikasjon.type === BrukernotifikasjonType.OPPGAVE }
@@ -42,11 +45,11 @@ class BrukernotifikasjonServiceTest {
 
     @Test
     fun `should not receieve any brukernotfikasjoner`() {
-        coEvery { oppgaveService.getOppgaveEventsAsBrukernotifikasjoner("1234") } returns emptyList()
-        coEvery { beskjedService.getBeskjedEventsAsBrukernotifikasjoner("1234") } returns emptyList()
-        coEvery { innboksService.getInnboksEventsAsBrukernotifikasjoner("1234") } returns emptyList()
+        coEvery { oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker) } returns emptyList()
+        coEvery { beskjedService.getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker) } returns emptyList()
+        coEvery { innboksService.getInnboksEventsAsBrukernotifikasjoner(innloggetBruker) } returns emptyList()
 
-        val brukernotifikasjoner = runBlocking { brukernotifikasjonService.getBrukernotifikasjoner("1234") }
+        val brukernotifikasjoner = runBlocking { brukernotifikasjonService.getBrukernotifikasjoner(innloggetBruker) }
         brukernotifikasjoner.size `should be equal to` 0
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonServiceTest.kt
@@ -4,7 +4,7 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.api.innboks.InnboksService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
 import org.amshove.kluent.`should be equal to`
@@ -22,7 +22,7 @@ class BrukernotifikasjonServiceTest {
     val oppgave1 = BrukernotfikasjonObjectMother.createOppgaveBrukernotifikasjon("3")
     val innboks1 = BrukernotfikasjonObjectMother.createInnboksBrukernotifikasjon("4")
 
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should receive brukernotfikasjoner of type Beskjed and Oppgave`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.common
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
 
 fun createInnloggetBruker(): InnloggetBruker {
@@ -13,5 +14,10 @@ fun createInnloggetBruker(): InnloggetBruker {
 
 fun createDummyTokenSupport(): OIDCValidationContextPrincipal {
     val tokenValidationContext = mockk<TokenValidationContext>()
-    return OIDCValidationContextPrincipal(tokenValidationContext)
+    val oidcValidationContextPrincipal = OIDCValidationContextPrincipal(tokenValidationContext)
+    val dummyJwtToken = mockk<JwtToken>()
+
+    every { oidcValidationContextPrincipal.context.firstValidToken.get() } returns dummyJwtToken
+
+    return oidcValidationContextPrincipal
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -6,16 +6,21 @@ import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.jwt.JwtToken
 import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
 
-fun createInnloggetBruker(): InnloggetBruker {
-    val innloggetBruker = mockk<InnloggetBruker>()
-    every { innloggetBruker.getBearerToken() } returns "dummyToken"
-    return innloggetBruker
-}
+object InnloggetBrukerObjectMother {
 
-fun createDummyTokenSupport(): OIDCValidationContextPrincipal {
-    val tokenValidationContext = mockk<TokenValidationContext>()
-    val oidcValidationContextPrincipal = OIDCValidationContextPrincipal(tokenValidationContext)
-    val dummyJwtToken = mockk<JwtToken>()
-    every { oidcValidationContextPrincipal.context.firstValidToken.get() } returns dummyJwtToken
-    return oidcValidationContextPrincipal
+    fun createInnloggetBruker(): InnloggetBruker {
+        val innloggetBruker = mockk<InnloggetBruker>()
+        every { innloggetBruker.getBearerToken() } returns "dummyToken"
+        return innloggetBruker
+    }
+
+    fun createDummyTokenSupport(): OIDCValidationContextPrincipal {
+        val tokenValidationContext = mockk<TokenValidationContext>()
+        val oidcValidationContextPrincipal = OIDCValidationContextPrincipal(tokenValidationContext)
+        val dummyJwtToken = mockk<JwtToken>()
+
+        every { oidcValidationContextPrincipal.context.firstValidToken.get() } returns dummyJwtToken
+
+        return oidcValidationContextPrincipal
+    }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -16,8 +16,6 @@ fun createDummyTokenSupport(): OIDCValidationContextPrincipal {
     val tokenValidationContext = mockk<TokenValidationContext>()
     val oidcValidationContextPrincipal = OIDCValidationContextPrincipal(tokenValidationContext)
     val dummyJwtToken = mockk<JwtToken>()
-
     every { oidcValidationContextPrincipal.context.firstValidToken.get() } returns dummyJwtToken
-
     return oidcValidationContextPrincipal
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -1,0 +1,17 @@
+package no.nav.personbruker.dittnav.api.common
+
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+
+fun createInnloggetBruker(): InnloggetBruker {
+    val innloggetBruker = mockk<InnloggetBruker>()
+    every { innloggetBruker.getBearerToken() } returns "dummyToken"
+    return innloggetBruker
+}
+
+fun createDummyTokenSupport(): OIDCValidationContextPrincipal {
+    val tokenValidationContext = mockk<TokenValidationContext>()
+    return OIDCValidationContextPrincipal(tokenValidationContext)
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test
 
 internal class InnloggetBrukerTest {
 
-    val tokenSupport = createDummyTokenSupport()
+    val tokenSupport = InnloggetBrukerObjectMother.createDummyTokenSupport()
     val innloggetBruker = InnloggetBruker(tokenSupport)
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
@@ -1,0 +1,52 @@
+package no.nav.personbruker.dittnav.api.common
+
+import io.mockk.coEvery
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+
+internal class InnloggetBrukerTest {
+
+    val tokenSupport = createDummyTokenSupport()
+    val innloggetBruker = InnloggetBruker(tokenSupport)
+
+    @Test
+    fun `should return string with token`() {
+        val expectedToken = "dummyToken"
+
+        coEvery({ tokenSupport.context.firstValidToken.get().tokenAsString }) returns expectedToken
+
+        runBlocking {
+            val tokenAsString = innloggetBruker.getTokenAsString()
+            tokenAsString `should be equal to` expectedToken
+        }
+    }
+
+    @Test
+    fun `should return string with Bearer token`() {
+        val expectedToken = "Bearer dummyToken"
+        val dummyToken = "dummyToken"
+
+        coEvery({ tokenSupport.context.firstValidToken.get().tokenAsString }) returns dummyToken
+
+        runBlocking {
+            val bearerToken = innloggetBruker.getBearerToken()
+            bearerToken `should be equal to` expectedToken
+        }
+    }
+
+    @Test
+    fun `should throw Exception if token is null`() {
+
+        coEvery({ tokenSupport.context.firstValidToken.get().tokenAsString }) returns null
+
+        invoking {
+            runBlocking {
+                innloggetBruker.getBearerToken()
+            }
+
+        } `should throw` Exception::class
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -21,7 +21,7 @@ import java.net.URL
 
 class InnboksConsumerTest {
 
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call innboks endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
@@ -10,10 +10,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.config.HttpClientBuilder
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -22,6 +20,8 @@ import org.junit.jupiter.api.Test
 import java.net.URL
 
 class InnboksConsumerTest {
+
+    val innloggetBruker = createInnloggetBruker()
 
     @Test
     fun `should call innboks endpoint on event handler`() {
@@ -42,7 +42,7 @@ class InnboksConsumerTest {
         val innboksConsumer = InnboksConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            innboksConsumer.getExternalEvents("1234") `should equal` emptyList()
+            innboksConsumer.getExternalEvents(innloggetBruker) `should equal` emptyList()
         }
 
     }
@@ -73,9 +73,9 @@ class InnboksConsumerTest {
         val innboksConsumer = InnboksConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            innboksConsumer.getExternalEvents("1234").size `should be equal to` 2
-            innboksConsumer.getExternalEvents("1234")[0].tekst `should be equal to` innboksObject1.tekst
-            innboksConsumer.getExternalEvents("1234")[0].fodselsnummer `should be equal to` innboksObject1.fodselsnummer
+            innboksConsumer.getExternalEvents(innloggetBruker).size `should be equal to` 2
+            innboksConsumer.getExternalEvents(innloggetBruker)[0].tekst `should be equal to` innboksObject1.tekst
+            innboksConsumer.getExternalEvents(innloggetBruker)[0].fodselsnummer `should be equal to` innboksObject1.fodselsnummer
         }
     }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.innboks
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -11,13 +12,14 @@ class InnboksServiceTest {
     val innboksService = InnboksService(innboksConsumer)
     val innboks1 = createInnboks("1", "1")
     val innboks2 = createInnboks("2", "2")
+    val innloggetBruker = createInnloggetBruker()
 
     @Test
     fun `should return list of Brukernotifikasjoner when Events are received`() {
-        coEvery { innboksConsumer.getExternalEvents("1234") } returns listOf(innboks1, innboks2)
+        coEvery { innboksConsumer.getExternalEvents(innloggetBruker) } returns listOf(innboks1, innboks2)
 
         runBlocking {
-            val brukernotifikasjonListe = innboksService.getInnboksEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = innboksService.getInnboksEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 2
         }
 
@@ -25,10 +27,10 @@ class InnboksServiceTest {
 
     @Test
     fun `should return empty list when Exception is thrown`() {
-        coEvery { innboksConsumer.getExternalEvents("1234") } throws Exception("error")
+        coEvery { innboksConsumer.getExternalEvents(innloggetBruker) } throws Exception("error")
 
         runBlocking {
-            val brukernotifikasjonListe = innboksService.getInnboksEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = innboksService.getInnboksEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 0
         }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.api.innboks
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -12,7 +12,7 @@ class InnboksServiceTest {
     val innboksService = InnboksService(innboksConsumer)
     val innboks1 = createInnboks("1", "1")
     val innboks2 = createInnboks("2", "2")
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should return list of Brukernotifikasjoner when Events are received`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
@@ -10,10 +10,10 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.config.*
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
+import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should equal`
 import org.junit.jupiter.api.Test
@@ -21,8 +21,11 @@ import java.net.URL
 
 class OppgaveConsumerTest {
 
+    val innloggetBruker = createInnloggetBruker()
+
     @Test
     fun `should call oppgave endpoint on event handler`() {
+
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler { request ->
@@ -41,13 +44,14 @@ class OppgaveConsumerTest {
         val oppgaveConsumer = OppgaveConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            oppgaveConsumer.getExternalEvents("1234") `should equal` emptyList()
+            oppgaveConsumer.getExternalEvents(innloggetBruker) `should equal` emptyList()
         }
 
     }
 
     @Test
     fun `should get list of Oppgave`() {
+
         val oppgaveObject1 = OppgaveObjectMother.createOppgave("1", "1")
         val oppgaveObject2 = OppgaveObjectMother.createOppgave("2", "2")
         val objectMapper = ObjectMapper().apply {
@@ -71,9 +75,9 @@ class OppgaveConsumerTest {
         val oppgaveConsumer = OppgaveConsumer(client, URL("http://event-handler"))
 
         runBlocking {
-            oppgaveConsumer.getExternalEvents("1234").size `should be equal to` 2
-            oppgaveConsumer.getExternalEvents("1234")[0].tekst `should be equal to` oppgaveObject1.tekst
-            oppgaveConsumer.getExternalEvents("1234")[0].fodselsnummer `should be equal to` oppgaveObject1.fodselsnummer
+            oppgaveConsumer.getExternalEvents(innloggetBruker).size `should be equal to` 2
+            oppgaveConsumer.getExternalEvents(innloggetBruker)[0].tekst `should be equal to` oppgaveObject1.tekst
+            oppgaveConsumer.getExternalEvents(innloggetBruker)[0].fodselsnummer `should be equal to` oppgaveObject1.fodselsnummer
         }
 
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
@@ -11,7 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -21,7 +21,7 @@ import java.net.URL
 
 class OppgaveConsumerTest {
 
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call oppgave endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.oppgave
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -13,13 +14,14 @@ class OppgaveServiceTest {
     val oppgaveService = OppgaveService(oppgaveConsumer)
     val oppgave1 = OppgaveObjectMother.createOppgave("1", "1")
     val oppgave2 = OppgaveObjectMother.createOppgave("2", "2")
+    val innloggetBruker = createInnloggetBruker()
 
     @Test
     fun `should return list of Brukernotifikasjoner when Events are received`() {
-        coEvery { oppgaveConsumer.getExternalEvents("1234") } returns listOf(oppgave1, oppgave2)
+        coEvery { oppgaveConsumer.getExternalEvents(innloggetBruker) } returns listOf(oppgave1, oppgave2)
 
         runBlocking {
-            val brukernotifikasjonListe = oppgaveService.getOppgaveEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 2
         }
 
@@ -27,10 +29,10 @@ class OppgaveServiceTest {
 
     @Test
     fun `should return empty List when Exception is thrown`() {
-        coEvery { oppgaveConsumer.getExternalEvents("1234") } throws Exception("error")
+        coEvery { oppgaveConsumer.getExternalEvents(innloggetBruker) } throws Exception("error")
 
         runBlocking {
-            val brukernotifikasjonListe = oppgaveService.getOppgaveEventsAsBrukernotifikasjoner("1234")
+            val brukernotifikasjonListe = oppgaveService.getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker)
             brukernotifikasjonListe.size `should be equal to` 0
         }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
@@ -3,7 +3,7 @@ package no.nav.personbruker.dittnav.api.oppgave
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import no.nav.personbruker.dittnav.api.common.createInnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -14,7 +14,7 @@ class OppgaveServiceTest {
     val oppgaveService = OppgaveService(oppgaveConsumer)
     val oppgave1 = OppgaveObjectMother.createOppgave("1", "1")
     val oppgave2 = OppgaveObjectMother.createOppgave("2", "2")
-    val innloggetBruker = createInnloggetBruker()
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should return list of Brukernotifikasjoner when Events are received`() {


### PR DESCRIPTION
Vi henter token gjennom Nav.security.token.support sin context. Det vil si vi tar ikke stilling til om token-et kommer fra header eller cookie. Validering og uthenting av token skal security biblioteket ta seg av. 

En liten refaktorering som gjør at vi wrapper token-et i InnloggetBruker objektet så vi kan samle all token logikk her. 

feature/PB-334-henter-innloggetbruker-fra-context