### PR TITLE
Gjort oppretteksen av InnloggetBruker mer robust

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,8 @@ val kluentVersion = "1.56"
 val tokensupportVersion = "1.1.0"
 val kotlinxCoroutinesVersion = "1.3.3"
 val kotlinxHtmlVersion = "0.6.12"
-
+val jjwtVersion = "0.11.0"
+val bcproVersion = "1.64"
 
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
@@ -23,7 +24,7 @@ plugins {
     kotlin("jvm").version(kotlinVersion)
     kotlin("plugin.allopen").version(kotlinVersion)
 
-    id("org.flywaydb.flyway") version("5.2.4")
+    id("org.flywaydb.flyway") version ("5.2.4")
 
     // Apply the application plugin to add support for building a CLI application.
     application
@@ -54,15 +55,15 @@ dependencies {
     compile("io.ktor:ktor-client-apache:$ktorVersion")
     compile("io.ktor:ktor-client-json:$ktorVersion")
     compile("io.ktor:ktor-client-serialization-jvm:$ktorVersion")
+    compile("io.ktor:ktor-jackson:$ktorVersion")
     compile("io.ktor:ktor-client-jackson:$ktorVersion")
-    compile("ch.qos.logback:logback-classic:$logbackVersion")
-    compile("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
+    compile("io.ktor:ktor-html-builder:$ktorVersion")
     compile("io.ktor:ktor-client-logging:$ktorVersion")
     compile("io.ktor:ktor-client-logging-jvm:$ktorVersion")
+    compile("ch.qos.logback:logback-classic:$logbackVersion")
+    compile("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
     compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    compile("io.ktor:ktor-jackson:$ktorVersion")
     compile("org.jetbrains.kotlinx:kotlinx-html-jvm:${kotlinxHtmlVersion}")
-    compile("io.ktor:ktor-html-builder:$ktorVersion")
     testCompile("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     testCompile(kotlin("test-junit5"))
     testCompile("io.ktor:ktor-client-mock:$ktorVersion")
@@ -71,6 +72,10 @@ dependencies {
     testImplementation("org.amshove.kluent:kluent:$kluentVersion")
     testImplementation("io.mockk:mockk:$mockKVersion")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    testCompile("io.jsonwebtoken:jjwt-api:$jjwtVersion")
+    testRuntime("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
+    testRuntime("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
+    testRuntime("org.bouncycastle:bcprov-jdk15on:$bcproVersion")
 }
 
 application {
@@ -98,6 +103,7 @@ tasks {
         environment("LEGACY_API_URL", "http://localhost:8090/person/dittnav-legacy-api")
         environment("EVENT_HANDLER_URL", "http://localhost:8092")
         environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
+        environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedService.kt
@@ -24,7 +24,7 @@ class BeskjedService(private val beskjedConsumer: BeskjedConsumer) {
     suspend fun getBeskjedEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
             beskjedConsumer.getExternalActiveEvents(innloggetBruker)
-                    .filter { beskjed ->  innloggetBruker.getSecurityLevel().level >= beskjed.sikkerhetsnivaa }
+                    .filter { beskjed -> innloggetBruker.innloggingsnivaa >= beskjed.sikkerhetsnivaa }
                     .map { beskjed -> toBrukernotifikasjon(beskjed) }
         } catch (exception: Exception) {
             log.error(exception)
@@ -54,6 +54,6 @@ class BeskjedService(private val beskjedConsumer: BeskjedConsumer) {
     }
 
     private fun innloggetBrukerIsAllowedToViewAllDataInEvent(beskjed: Beskjed, innloggetBruker: InnloggetBruker): Boolean {
-        return innloggetBruker.getSecurityLevel().level >= beskjed.sikkerhetsnivaa;
+        return innloggetBruker.innloggingsnivaa >= beskjed.sikkerhetsnivaa
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -4,7 +4,7 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.beskjed(beskjedService: BeskjedService) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -4,7 +4,7 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.brukernotifikasjoner(brukernotifikasjonService: BrukernotifikasjonService) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/IdentityClaim.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/IdentityClaim.kt
@@ -1,0 +1,24 @@
+package no.nav.personbruker.dittnav.api.common
+
+enum class IdentityClaim(val claimName: String) {
+
+    SUBJECT("sub"),
+    PID("pid");
+
+    companion object {
+        fun fromClaimName(claimName: String): IdentityClaim {
+            values().forEach { currentClaim ->
+                if (currentClaim.claimName == claimName.toLowerCase()) {
+                    return currentClaim
+                }
+            }
+            val msg = "Ugyldig claim name '$claimName', gyldige verdier er ${values().toSet()}"
+            throw IllegalArgumentException(msg)
+        }
+    }
+
+    override fun toString(): String {
+        return "IdentidyClaim(claimName='$claimName')"
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
@@ -1,10 +1,5 @@
 package no.nav.personbruker.dittnav.api.common
 
-import io.ktor.application.ApplicationCall
-import io.ktor.application.call
-import io.ktor.auth.authentication
-import io.ktor.util.pipeline.PipelineContext
-
 data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val token: String) {
 
     fun createAuthenticationHeader(): String {
@@ -16,6 +11,3 @@ data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val tok
     }
 
 }
-
-val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
-    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
@@ -4,45 +4,18 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.auth.authentication
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
 
-class InnloggetBruker(val token: JwtToken) {
+data class InnloggetBruker(val ident: String, val innloggingsnivaa: Int, val token: String) {
 
-    fun getBearerToken(): String {
-        return "Bearer " + token.tokenAsString
+    fun createAuthenticationHeader(): String {
+        return "Bearer $token"
     }
 
-    fun getIdentFromToken(): String {
-        val ident = token.jwtTokenClaims.getStringClaim("sub")
-
-        if (isClaimElevenDigitsOrLess(ident)) {
-            return ident
-        }
-        return token.jwtTokenClaims.getStringClaim("pid")
+    override fun toString(): String {
+        return "InnloggetBruker(ident='***', innloggingsnivaa=$innloggingsnivaa, token='***')"
     }
 
-    fun getSecurityLevel(): SecurityLevel {
-        val levelClaim = token.jwtTokenClaims.getStringClaim("acr")
-        val level = when(levelClaim) {
-            "Level3" -> SecurityLevel.Level3
-            "Level4" -> SecurityLevel.Level4
-            else -> SecurityLevel.Ukjent
-        }
-        return level
-    }
-
-
-    private fun isClaimElevenDigitsOrLess(ident: String): Boolean {
-        val regex = """\d{1,11}""".toRegex()
-        return regex.matches(ident)
-    }
 }
 
-val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker get() =
-    call.authentication.principal<OIDCValidationContextPrincipal>()
-            ?.context
-            ?.firstValidToken
-            ?.map { token -> InnloggetBruker(token) }
-            ?.get()
-            ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
+val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
+    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
@@ -25,7 +25,7 @@ object InnloggetBrukerFactory {
         return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString)
     }
 
-    fun extractInnloggingsnivaa(token: JwtToken): Int {
+    private fun extractInnloggingsnivaa(token: JwtToken): Int {
         val innloggingsnivaaClaim = token.jwtTokenClaims.getStringClaim("acr")
 
         return when (innloggingsnivaaClaim) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
@@ -1,0 +1,38 @@
+package no.nav.personbruker.dittnav.api.common
+
+import no.nav.personbruker.dittnav.api.config.getOptionalEnvVar
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+
+object InnloggetBrukerFactory {
+
+    private val IDENT_CLAIM: IdentityClaim
+    private val defaultClaim = IdentityClaim.SUBJECT
+    private val oidcIdentityClaimName = "OIDC_CLAIM_CONTAINING_THE_IDENTITY"
+
+    init {
+        val identityClaimFromEnvVariable = getOptionalEnvVar(oidcIdentityClaimName, defaultClaim.claimName)
+        IDENT_CLAIM = IdentityClaim.fromClaimName(identityClaimFromEnvVariable)
+    }
+
+    fun createNewInnloggetBruker(principal: OIDCValidationContextPrincipal?): InnloggetBruker {
+        val token = principal?.context?.firstValidToken?.get()
+                ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
+
+        val ident: String = token.jwtTokenClaims.getStringClaim(IDENT_CLAIM.claimName)
+        val innloggingsnivaa = extractInnloggingsnivaa(token)
+
+        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString)
+    }
+
+    fun extractInnloggingsnivaa(token: JwtToken): Int {
+        val innloggingsnivaaClaim = token.jwtTokenClaims.getStringClaim("acr")
+
+        return when (innloggingsnivaaClaim) {
+            "Level3" -> 3
+            "Level4" -> 4
+            else -> throw Exception("Innloggingsnivå ble ikke funnet. Dette skal ikke kunne skje.")
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/SecurityLevel.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/SecurityLevel.kt
@@ -1,7 +1,0 @@
-package no.nav.personbruker.dittnav.api.common
-
-enum class SecurityLevel (val level: Int) {
-    Level3(3),
-    Level4(4),
-    Ukjent(-1)
-}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -3,6 +3,7 @@ package no.nav.personbruker.dittnav.api.config
 import io.ktor.application.*
 import io.ktor.auth.Authentication
 import io.ktor.auth.authenticate
+import io.ktor.auth.authentication
 import io.ktor.client.HttpClient
 import io.ktor.features.CORS
 import io.ktor.features.ContentNegotiation
@@ -11,24 +12,27 @@ import io.ktor.http.HttpHeaders
 import io.ktor.jackson.jackson
 import io.ktor.routing.routing
 import io.ktor.util.KtorExperimentalAPI
+import io.ktor.util.pipeline.PipelineContext
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedConsumer
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
-import no.nav.personbruker.dittnav.api.oppgave.oppgave
 import no.nav.personbruker.dittnav.api.beskjed.beskjed
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.BrukernotifikasjonService
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.brukernotifikasjoner
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerFactory
 import no.nav.personbruker.dittnav.api.done.DoneProducer
 import no.nav.personbruker.dittnav.api.done.doneApi
-import no.nav.personbruker.dittnav.api.innboks.innboks
-import no.nav.personbruker.dittnav.api.health.healthApi
 import no.nav.personbruker.dittnav.api.health.authenticationCheck
+import no.nav.personbruker.dittnav.api.health.healthApi
 import no.nav.personbruker.dittnav.api.innboks.InnboksConsumer
 import no.nav.personbruker.dittnav.api.innboks.InnboksService
+import no.nav.personbruker.dittnav.api.innboks.innboks
 import no.nav.personbruker.dittnav.api.legacy.LegacyConsumer
 import no.nav.personbruker.dittnav.api.legacy.legacyApi
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveConsumer
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
+import no.nav.personbruker.dittnav.api.oppgave.oppgave
 import no.nav.security.token.support.ktor.tokenValidationSupport
 
 @KtorExperimentalAPI
@@ -94,3 +98,6 @@ private fun Application.configureShutdownHook(httpClient: HttpClient) {
         httpClient.close()
     }
 }
+
+val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
+    get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -15,6 +15,6 @@ suspend inline fun <reified T> HttpClient.get(url: URL, innloggetBruker: Innlogg
     request<T> {
         url(url)
         method = HttpMethod.Get
-        header(HttpHeaders.Authorization, innloggetBruker.getBearerToken())
+        header(HttpHeaders.Authorization, innloggetBruker.createAuthenticationHeader())
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/done/DoneProducer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/done/DoneProducer.kt
@@ -12,7 +12,6 @@ import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import org.slf4j.LoggerFactory
 import java.net.URL
 
-
 class DoneProducer(private val httpClient: HttpClient, dittNAVBaseURL: URL) {
 
     private val log = LoggerFactory.getLogger(DoneProducer::class.java)
@@ -31,7 +30,7 @@ class DoneProducer(private val httpClient: HttpClient, dittNAVBaseURL: URL) {
         httpClient.post<T>() {
             url(url)
             method = HttpMethod.Post
-            header(HttpHeaders.Authorization, innloggetBruker.getBearerToken())
+            header(HttpHeaders.Authorization, innloggetBruker.createAuthenticationHeader())
             contentType(ContentType.Application.Json)
             body = done
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
@@ -8,7 +8,7 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.post
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.doneApi(doneProducer: DoneProducer) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksService.kt
@@ -24,7 +24,7 @@ class InnboksService (private val innboksConsumer: InnboksConsumer) {
     suspend fun getInnboksEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
             innboksConsumer.getExternalActiveEvents(innloggetBruker)
-                    .filter { innboks -> innloggetBruker.getSecurityLevel().level >= innboks.sikkerhetsnivaa }
+                    .filter { innboks -> innloggetBruker.innloggingsnivaa >= innboks.sikkerhetsnivaa }
                     .map { innboks-> toBrukernotifikasjon(innboks) }
         } catch (exception: Exception) {
             log.error(exception)
@@ -54,6 +54,6 @@ class InnboksService (private val innboksConsumer: InnboksConsumer) {
     }
 
     private fun innloggetBrukerIsAllowedToViewAllDataInEvent(innboks: Innboks, innloggetBruker: InnloggetBruker): Boolean {
-        return innloggetBruker.getSecurityLevel().level >= innboks.sikkerhetsnivaa;
+        return innloggetBruker.innloggingsnivaa >= innboks.sikkerhetsnivaa
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
@@ -4,7 +4,7 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.innboks(innboksService: InnboksService) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -7,7 +7,7 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.util.pipeline.PipelineContext
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.legacyApi(legacyConsumer: LegacyConsumer) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveService.kt
@@ -24,7 +24,7 @@ class OppgaveService(private val oppgaveConsumer: OppgaveConsumer) {
     suspend fun getOppgaveEventsAsBrukernotifikasjoner(innloggetBruker: InnloggetBruker): List<Brukernotifikasjon> {
         return try {
             oppgaveConsumer.getExternalActiveEvents(innloggetBruker)
-                    .filter { oppgave -> innloggetBruker.getSecurityLevel().level >= oppgave.sikkerhetsnivaa}
+                    .filter { oppgave -> innloggetBruker.innloggingsnivaa >= oppgave.sikkerhetsnivaa }
                     .map { oppgave -> toBrukernotifikasjon(oppgave) }
         } catch (exception: Exception) {
             log.error(exception)
@@ -54,6 +54,6 @@ class OppgaveService(private val oppgaveConsumer: OppgaveConsumer) {
     }
 
     private fun innloggetBrukerIsAllowedToViewAllDataInEvent(oppgave: Oppgave, innloggetBruker: InnloggetBruker): Boolean {
-        return innloggetBruker.getSecurityLevel().level >= oppgave.sikkerhetsnivaa;
+        return innloggetBruker.innloggingsnivaa >= oppgave.sikkerhetsnivaa
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
@@ -4,7 +4,7 @@ import io.ktor.application.call
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.common.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
 
 fun Route.oppgave(oppgaveService: OppgaveService) {
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
@@ -2,7 +2,10 @@ package no.nav.personbruker.dittnav.api.beskjed
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.mock.*
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
 import io.ktor.client.features.json.JsonFeature
 import io.ktor.client.request.HttpResponseData
 import io.ktor.http.ContentType
@@ -11,7 +14,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -23,7 +25,7 @@ import java.net.URL
 
 class BeskjedConsumerTest {
 
-    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call information endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedServiceTest.kt
@@ -4,22 +4,20 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
-
 class BeskjedServiceTest {
 
-    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     val beskjedConsumer = mockk<BeskjedConsumer>()
     val beskjedService = BeskjedService(beskjedConsumer)
 
     @Test
     fun `should return list of BeskjedDTO when active Events are received`() {
-        var beskjed1 = createBeskjed("1", "1", "1", true)
-        var beskjed2 = createBeskjed("2", "2", "2", true)
+        val beskjed1 = createBeskjed("1", "1", "1", true)
+        val beskjed2 = createBeskjed("2", "2", "2", true)
         coEvery { beskjedConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(beskjed1, beskjed2)
         runBlocking {
             val brukernotifikasjonListe = beskjedService.getActiveBeskjedEvents(innloggetBruker)
@@ -29,8 +27,8 @@ class BeskjedServiceTest {
 
     @Test
     fun `should return list of BeskjedDTO when inactive Events are received`() {
-        var beskjed1 = createBeskjed("1", "1", "1", false)
-        var beskjed2 = createBeskjed("2", "2", "2", false)
+        val beskjed1 = createBeskjed("1", "1", "1", false)
+        val beskjed2 = createBeskjed("2", "2", "2", false)
         coEvery { beskjedConsumer.getExternalInactiveEvents(innloggetBruker) } returns listOf(beskjed1, beskjed2)
         runBlocking {
             val brukernotifikasjonListe = beskjedService.getInactiveBeskjedEvents(innloggetBruker)
@@ -50,9 +48,10 @@ class BeskjedServiceTest {
 
     @Test
     fun `should mask events with security level higher than current user`() {
-        var beskjed = createBeskjed("1", "1", "1", true)
+        val ident = "1"
+        var beskjed = createBeskjed("1", ident, "1", true)
         beskjed = beskjed.copy(sikkerhetsnivaa = 4)
-        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level3)
+        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(ident, 3)
         coEvery { beskjedConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(beskjed)
         runBlocking {
             val beskjedList = beskjedService.getActiveBeskjedEvents(innloggetBruker)
@@ -79,7 +78,7 @@ class BeskjedServiceTest {
 
     @Test
     fun `should not mask events with security level equal than current user`() {
-        var beskjed = createBeskjed("1", "1", "1", true)
+        val beskjed = createBeskjed("1", "1", "1", true)
         coEvery { beskjedConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(beskjed)
         runBlocking {
             val beskjedList = beskjedService.getActiveBeskjedEvents(innloggetBruker)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/IdentityClaimTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/IdentityClaimTest.kt
@@ -1,0 +1,25 @@
+package no.nav.personbruker.dittnav.api.common
+
+import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+
+internal class IdentityClaimTest {
+
+    @Test
+    fun `should convert valid strings to enum`() {
+        IdentityClaim.fromClaimName("pid") `should equal` IdentityClaim.PID
+        IdentityClaim.fromClaimName("PID") `should equal` IdentityClaim.PID
+        IdentityClaim.fromClaimName("sub") `should equal` IdentityClaim.SUBJECT
+        IdentityClaim.fromClaimName("SUB") `should equal` IdentityClaim.SUBJECT
+    }
+
+    @Test
+    fun `should throw exception if invalid value is received`() {
+        invoking {
+            IdentityClaim.fromClaimName("")
+        } `should throw` IllegalArgumentException::class
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactoryTest.kt
@@ -1,0 +1,46 @@
+package no.nav.personbruker.dittnav.api.common
+
+import no.nav.personbruker.dittnav.api.common.OIDCValidationContextPrincipalObjectMother.createPrincipalForAzure
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldNotBeNullOrBlank
+import org.junit.jupiter.api.Test
+import java.util.*
+
+internal class InnloggetBrukerFactoryTest {
+
+    @Test
+    fun `should throw exception if principal is missing`() {
+        invoking {
+            InnloggetBrukerFactory.createNewInnloggetBruker(null)
+        } `should throw` Exception::class
+    }
+
+    @Test
+    fun `should throw exception if the token context is empty`() {
+        val context = TokenValidationContext(emptyMap())
+        val principal = OIDCValidationContextPrincipal(context)
+        invoking {
+            InnloggetBrukerFactory.createNewInnloggetBruker(principal)
+        } `should throw` NoSuchElementException::class
+    }
+
+    @Test
+    fun `should extract identity from the claim with the name sub for tokens form Azure`() {
+        val expectedIdent = "000"
+        val expectedInnloggingsnivaa = 3
+
+        val principal = createPrincipalForAzure(expectedIdent, expectedInnloggingsnivaa)
+
+
+        val innloggetBruker = InnloggetBrukerFactory.createNewInnloggetBruker(principal)
+
+        innloggetBruker.ident `should be equal to` expectedIdent
+        innloggetBruker.innloggingsnivaa `should be equal to` expectedInnloggingsnivaa
+        innloggetBruker.token.shouldNotBeNullOrBlank()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -1,16 +1,32 @@
 package no.nav.personbruker.dittnav.api.common
 
-import io.mockk.every
-import io.mockk.mockk
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
 import no.nav.security.token.support.core.jwt.JwtToken
+import java.security.Key
 
 object InnloggetBrukerObjectMother {
 
-    fun createInnloggetBruker(securityLevel: SecurityLevel): InnloggetBruker {
-        val dummyJwtToken = mockk<JwtToken>()
-        val dummyTokenAsString = "dummyToken"
-        every { dummyJwtToken.tokenAsString} returns dummyTokenAsString
-        every { dummyJwtToken.jwtTokenClaims.getStringClaim("acr")} returns securityLevel.toString()
-        return InnloggetBruker(dummyJwtToken)
+    private val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+
+    fun createInnloggetBruker(): InnloggetBruker {
+        val ident = "12345"
+        return createInnloggetBruker(ident)
     }
+
+    fun createInnloggetBruker(ident: String): InnloggetBruker {
+        val innloggingsnivaa = 4
+        return createInnloggetBruker(ident, innloggingsnivaa)
+    }
+
+    fun createInnloggetBruker(ident: String, innloggingsnivaa: Int): InnloggetBruker {
+        val jws = Jwts.builder()
+                .setSubject(ident)
+                .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)
+                .signWith(key).compact()
+        val token = JwtToken(jws)
+        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString)
+    }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
@@ -1,93 +1,43 @@
 package no.nav.personbruker.dittnav.api.common
 
-import io.mockk.coEvery
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should equal`
+import org.amshove.kluent.`should contain`
+import org.amshove.kluent.`should not contain`
+import org.amshove.kluent.shouldNotBeNullOrBlank
 import org.junit.jupiter.api.Test
 
 internal class InnloggetBrukerTest {
 
-    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
-
     @Test
-    fun `should return string with Bearer token`() {
-        val expectedToken = "Bearer dummyToken"
+    fun `should return expected values`() {
+        val expectedIdent = "12345"
+        val expectedInnloggingsnivaa = 4
 
-        runBlocking {
-            val actualToken = innloggetBruker.getBearerToken()
-            actualToken `should be equal to` expectedToken
-        }
+        val innloggetbruker = InnloggetBrukerObjectMother.createInnloggetBruker(expectedIdent, expectedInnloggingsnivaa)
+
+        innloggetbruker.ident `should be equal to` expectedIdent
+        innloggetbruker.innloggingsnivaa `should be equal to` expectedInnloggingsnivaa
+        innloggetbruker.token.shouldNotBeNullOrBlank()
     }
 
     @Test
-    fun `should return string with ident from pid token claim`() {
-        val expectedIdent = "dummyIdent"
-        val subClaimThatIsNotAnIdent ="dummyClaimThatIsNotAnIdent"
+    fun `should create authentication header`() {
+        val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid")} returns expectedIdent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub")} returns subClaimThatIsNotAnIdent
+        val generatedAuthHeader = innloggetBruker.createAuthenticationHeader()
 
-        runBlocking {
-            val actualIdent = innloggetBruker.getIdentFromToken()
-            actualIdent `should be equal to` expectedIdent
-        }
+        generatedAuthHeader `should be equal to` "Bearer ${innloggetBruker.token}"
     }
 
     @Test
-    fun `should return string with ident from sub token claim`() {
-        val expectedIdent = "123"
+    fun `should not include sensitive values in the output for the toString method`() {
+        val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("pid")} returns null
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("sub")} returns expectedIdent
+        val outputOfToString = innloggetBruker.toString()
 
-        runBlocking {
-            val actualIdent = innloggetBruker.getIdentFromToken()
-            actualIdent `should be equal to` expectedIdent
-        }
+        outputOfToString `should contain` (innloggetBruker.innloggingsnivaa.toString())
+        outputOfToString `should not contain` (innloggetBruker.ident)
+        outputOfToString `should not contain` (innloggetBruker.token)
     }
 
-    @Test
-    fun `should return security level 4 from acr token claim`() {
-        val expectedLevel = SecurityLevel.Level4
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("acr")} returns "Level4"
-
-        runBlocking {
-            val actualLevel = innloggetBruker.getSecurityLevel()
-            actualLevel `should equal` expectedLevel
-        }
-    }
-
-    @Test
-    fun `should return security level 3 from acr token claim`() {
-        val expectedLevel = SecurityLevel.Level3
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("acr")} returns "Level3"
-
-        runBlocking {
-            val actualLevel = innloggetBruker.getSecurityLevel()
-            actualLevel `should equal` expectedLevel
-        }
-    }
-
-    @Test
-    fun `should return unknown level from acr token claim`() {
-        val expectedLevel = SecurityLevel.Ukjent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("acr")} returns "dummy"
-
-        runBlocking {
-            val actualLevel = innloggetBruker.getSecurityLevel()
-            actualLevel `should equal` expectedLevel
-        }
-    }
-
-    @Test
-    fun `should return int indicating unknown level if acr claim is missing`() {
-        val expectedLevel = SecurityLevel.Ukjent
-        coEvery { innloggetBruker.token.jwtTokenClaims.getStringClaim("acr")} returns null
-
-        runBlocking {
-            val actualLevel = innloggetBruker.getSecurityLevel()
-            actualLevel `should equal` expectedLevel
-        }
-    }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/OIDCValidationContextPrincipalObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/OIDCValidationContextPrincipalObjectMother.kt
@@ -1,0 +1,57 @@
+package no.nav.personbruker.dittnav.api.common
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import java.security.Key
+import java.time.Instant
+import java.util.*
+
+object OIDCValidationContextPrincipalObjectMother {
+
+    fun createPrincipalForAzure(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
+        val expiredJws = Jwts.builder()
+                .setSubject(ident)
+                .setExpiration(inTwoMinutes)
+                .addClaims(
+                        mutableMapOf(
+                                Pair("acr", "Level$innloggingsnivaa"
+                                )) as Map<String, Any>?)
+                .signWith(key).compact()
+
+        val token = JwtToken(expiredJws)
+
+        val issuerShortNameValidatedTokenMap = mutableMapOf<String, JwtToken>()
+        val issuer = "keyForIssuer"
+        issuerShortNameValidatedTokenMap[issuer] = token
+        val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
+        return OIDCValidationContextPrincipal(context)
+    }
+
+    fun createPrincipalForIdPorten(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+        val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
+        val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
+        val expiredJws = Jwts.builder()
+                .setExpiration(inTwoMinutes)
+                .addClaims(
+                        mutableMapOf(
+                                Pair("acr", "Level$innloggingsnivaa"),
+                                Pair("pid", ident)
+                        ) as Map<String, Any>?)
+                .signWith(key).compact()
+
+        val token = JwtToken(expiredJws)
+
+        val issuerShortNameValidatedTokenMap = mutableMapOf<String, JwtToken>()
+        val issuer = "keyForIssuer"
+        issuerShortNameValidatedTokenMap[issuer] = token
+        val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
+        return OIDCValidationContextPrincipal(context)
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/done/DoneProducerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/done/DoneProducerTest.kt
@@ -9,7 +9,6 @@ import io.ktor.client.statement.request
 import io.ktor.http.*
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import org.amshove.kluent.`should equal`
 import org.junit.jupiter.api.Test
@@ -17,7 +16,7 @@ import java.net.URL
 
 internal class DoneProducerTest {
 
-    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call post endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksConsumerTest.kt
@@ -14,7 +14,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -26,7 +25,7 @@ import java.net.URL
 
 class InnboksConsumerTest {
 
-    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call innboks endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/innboks/InnboksServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -12,7 +11,7 @@ class InnboksServiceTest {
     val innboksConsumer = mockk<InnboksConsumer>()
     val innboksService = InnboksService(innboksConsumer)
 
-    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should return list of InnboksDTO when active Events are received`() {
@@ -48,9 +47,10 @@ class InnboksServiceTest {
 
     @Test
     fun `should mask events with security level higher than current user`() {
-        var innboks = createInnboks("1", "1", true)
+        val ident = "1"
+        var innboks = createInnboks("1", ident, true)
         innboks = innboks.copy(sikkerhetsnivaa = 4)
-        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level3)
+        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(ident, 3)
         coEvery { innboksConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(innboks)
         runBlocking {
             val innboksList = innboksService.getActiveInnboksEvents(innloggetBruker)
@@ -77,7 +77,7 @@ class InnboksServiceTest {
 
     @Test
     fun `should not mask events with security level equal than current user`() {
-        var innboks = createInnboks("1", "1", true)
+        val innboks = createInnboks("1", "1", true)
         coEvery { innboksConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(innboks)
         runBlocking {
             val innboksList = innboksService.getActiveInnboksEvents(innloggetBruker)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveConsumerTest.kt
@@ -14,7 +14,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
 import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should be equal to`
@@ -26,7 +25,7 @@ import java.net.URL
 
 class OppgaveConsumerTest {
 
-    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should call oppgave endpoint on event handler`() {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
-import no.nav.personbruker.dittnav.api.common.SecurityLevel
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 
@@ -12,7 +11,7 @@ class OppgaveServiceTest {
 
     val oppgaveConsumer = mockk<OppgaveConsumer>()
     val oppgaveService = OppgaveService(oppgaveConsumer)
-    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level4)
+    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
     fun `should return list of OppgaveDTO when active Events are received`() {
@@ -48,9 +47,10 @@ class OppgaveServiceTest {
 
     @Test
     fun `should mask events with security level higher than current user`() {
-        var oppgave = createOppgave("1", "1", true)
+        val ident = "1"
+        var oppgave = createOppgave("1", ident, true)
         oppgave = oppgave.copy(sikkerhetsnivaa = 4)
-        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(SecurityLevel.Level3)
+        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(ident, 3)
         coEvery { oppgaveConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(oppgave)
         runBlocking {
             val oppgaveList = oppgaveService.getActiveOppgaveEvents(innloggetBruker)
@@ -77,7 +77,7 @@ class OppgaveServiceTest {
 
     @Test
     fun `should not mask events with security level equal than current user`() {
-        var oppgave = createOppgave("1", "1", true)
+        val oppgave = createOppgave("1", "1", true)
         coEvery { oppgaveConsumer.getExternalActiveEvents(innloggetBruker) } returns listOf(oppgave)
         runBlocking {
             val oppgaveList = oppgaveService.getActiveOppgaveEvents(innloggetBruker)


### PR DESCRIPTION
* For alle request-er hvor en bruker er autentisert skal det opprettes en instans av InnloggetBruker, denne opprettelsen har nå blitt gjort mer robust og det er lagt til tester.
* Innholdet i InnloggetBruker er ikke lengre mock-et, men bruker dummy-instanser av gyldige kortlevde token.
* InnloggetBruker sin toString-metode returnerer ikke sensitiv informasjon.

PB-369. Enkelte ganger blir ikke InnloggetBruker satt riktig