### PR TITLE
Appen vil nå stoppe hvis ikke alle miljøvariabler er satt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,12 @@ tasks {
         environment("LEGACY_API_URL", "http://localhost:8090/person/dittnav-legacy-api")
         environment("EVENT_HANDLER_URL", "http://localhost:8092")
         environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
+
+        environment("OIDC_ISSUER", "http://localhost:9000")
+        environment("OIDC_DISCOVERY_URL", "http://localhost:9000/.well-known/openid-configuration")
+        environment("OIDC_ACCEPTED_AUDIENCE", "stubOidcClient")
         environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
+
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath
     }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
@@ -10,8 +10,8 @@ data class Environment(
 )
 
 fun getEnvVar(varName: String): String {
-    val varValue = System.getenv(varName)
-    return varValue ?: throw IllegalArgumentException("Variable $varName cannot be empty")
+    return System.getenv(varName)
+            ?: throw IllegalArgumentException("Appen kan ikke starte uten av miljøvariabelen $varName er satt.")
 }
 
 fun getOptionalEnvVar(varName: String, defaultValue: String): String {

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -13,11 +13,8 @@ ktor {
 no.nav.security.jwt {
     issuers = [
         {
-            issuer_name = "http://localhost:9000"
             issuer_name = ${?OIDC_ISSUER}
-            discoveryurl = "http://localhost:9000/.well-known/openid-configuration"
             discoveryurl = ${?OIDC_DISCOVERY_URL}
-            accepted_audience = "stubOidcClient"
             accepted_audience = ${?OIDC_ACCEPTED_AUDIENCE}
             cookie_name = selvbetjening-idtoken
         }


### PR DESCRIPTION
Default-verdiene som brukes ved lokal kjøring er flyttet ut til å bli satt i build.gradle.kts (se runServer).

PB-375. Alle apper skal stoppe hvis konfig mangler