### PR TITLE
Bytter til standard ingress i prod, slik at vi følger NAV sin standar…

### DIFF
--- a/nais/dev-sbs/q0.json
+++ b/nais/dev-sbs/q0.json
@@ -2,6 +2,7 @@
   "namespace": "q0",
   "ingresses": [
     "https://dittnav-api-q0.dev-sbs.nais.io/person/dittnav-api",
+    "https://dittnav-api-q0.nais.oera-q.local/person/dittnav-api",
     "https://www-q0.nav.no/person/dittnav-api"
   ]
 }

--- a/nais/dev-sbs/q1.json
+++ b/nais/dev-sbs/q1.json
@@ -2,6 +2,7 @@
   "namespace": "q1",
   "ingresses": [
     "https://dittnav-api-q1.dev-sbs.nais.io/person/dittnav-api",
+    "https://dittnav-api-q1.nais.oera-q.local/person/dittnav-api",
     "https://www-q1.nav.no/person/dittnav-api"
   ]
 }

--- a/nais/dev-sbs/q6.json
+++ b/nais/dev-sbs/q6.json
@@ -2,6 +2,7 @@
   "namespace": "q6",
   "ingresses": [
     "https://dittnav-api-q6.dev-sbs.nais.io/person/dittnav-api",
+    "https://dittnav-api-q6.nais.oera-q.local/person/dittnav-api",
     "https://www-q6.nav.no/person/dittnav-api"
   ]
 }

--- a/nais/prod-sbs/default.json
+++ b/nais/prod-sbs/default.json
@@ -2,6 +2,7 @@
   "namespace": "default",
   "ingresses": [
     "https://dittnav-api.prod-sbs.nais.io/person/dittnav-api",
+    "https://dittnav-api.nais.oera.no/person/dittnav-api",
     "https://www.nav.no/person/dittnav-api"
   ]
 }


### PR DESCRIPTION
…d og appen dukker opp i Grafana-dashboard-et.

Dette er i henhold til dokumentasjonen her: https://doc.nais.io/clusters#on-premise

Beholder midlertidig nais.io, siden det kan være noe overvåkningsapper som bruker den.