### PR TITLE
Forbedre timeout feil fra legacy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val prometheusVersion = "0.8.1"
-val ktorVersion = "1.3.1"
+val ktorVersion = "1.3.2"
 val logstashVersion = 5.2
 val logbackVersion = "1.2.3"
 val kotlinVersion = "1.3.50"
@@ -12,7 +12,7 @@ val mockKVersion = "1.9.3"
 val assertJVersion = "3.12.2"
 val junitVersion = "5.4.1"
 val kluentVersion = "1.56"
-val tokensupportVersion = "1.1.0"
+val tokensupportVersion = "1.3.0"
 val kotlinxCoroutinesVersion = "1.3.3"
 val kotlinxHtmlVersion = "0.6.12"
 val jjwtVersion = "0.11.0"

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactory.kt
@@ -2,7 +2,7 @@ package no.nav.personbruker.dittnav.api.common
 
 import no.nav.personbruker.dittnav.api.config.getOptionalEnvVar
 import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import no.nav.security.token.support.ktor.TokenValidationContextPrincipal
 import java.time.LocalDateTime
 import java.time.ZoneId
 
@@ -17,7 +17,7 @@ object InnloggetBrukerFactory {
         IDENT_CLAIM = IdentityClaim.fromClaimName(identityClaimFromEnvVariable)
     }
 
-    fun createNewInnloggetBruker(principal: OIDCValidationContextPrincipal?): InnloggetBruker {
+    fun createNewInnloggetBruker(principal: TokenValidationContextPrincipal?): InnloggetBruker {
         val token = principal?.context?.firstValidToken?.get()
                 ?: throw Exception("Det ble ikke funnet noe token. Dette skal ikke kunne skje.")
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -26,7 +26,7 @@ suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, innlogget
         method = HttpMethod.Get
         header(HttpHeaders.Authorization, innloggetBruker.createAuthenticationHeader())
         timeout {
-            socketTimeoutMillis = 10000
+            socketTimeoutMillis = 15000
             connectTimeoutMillis = 10000
             requestTimeoutMillis = 35000
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -26,7 +26,7 @@ suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, innlogget
         method = HttpMethod.Get
         header(HttpHeaders.Authorization, innloggetBruker.createAuthenticationHeader())
         timeout {
-            socketTimeoutMillis = 15000
+            socketTimeoutMillis = 20000
             connectTimeoutMillis = 10000
             requestTimeoutMillis = 35000
         }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,6 +11,7 @@ ktor {
 }
 
 no.nav.security.jwt {
+    expirythreshold = 2 #threshold in minutes until token expires
     issuers = [
         {
             issuer_name = ${?OIDC_ISSUER}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactoryTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerFactoryTest.kt
@@ -1,8 +1,8 @@
 package no.nav.personbruker.dittnav.api.common
 
-import no.nav.personbruker.dittnav.api.common.OIDCValidationContextPrincipalObjectMother.createPrincipalForAzure
+import no.nav.personbruker.dittnav.api.common.TokenValidationContextPrincipalObjectMother.createPrincipalForAzure
 import no.nav.security.token.support.core.context.TokenValidationContext
-import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import no.nav.security.token.support.ktor.TokenValidationContextPrincipal
 import org.amshove.kluent.*
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
@@ -20,7 +20,7 @@ internal class InnloggetBrukerFactoryTest {
     @Test
     fun `should throw exception if the token context is empty`() {
         val context = TokenValidationContext(emptyMap())
-        val principal = OIDCValidationContextPrincipal(context)
+        val principal = TokenValidationContextPrincipal(context)
         invoking {
             InnloggetBrukerFactory.createNewInnloggetBruker(principal)
         } `should throw` NoSuchElementException::class

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/TokenValidationContextPrincipalObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/TokenValidationContextPrincipalObjectMother.kt
@@ -5,14 +5,14 @@ import io.jsonwebtoken.SignatureAlgorithm
 import io.jsonwebtoken.security.Keys
 import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.jwt.JwtToken
-import no.nav.security.token.support.ktor.OIDCValidationContextPrincipal
+import no.nav.security.token.support.ktor.TokenValidationContextPrincipal
 import java.security.Key
 import java.time.Instant
 import java.util.*
 
-object OIDCValidationContextPrincipalObjectMother {
+object TokenValidationContextPrincipalObjectMother {
 
-    fun createPrincipalForAzure(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+    fun createPrincipalForAzure(ident: String, innloggingsnivaa: Int): TokenValidationContextPrincipal {
         val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
         val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
         val expiredJws = Jwts.builder()
@@ -30,10 +30,10 @@ object OIDCValidationContextPrincipalObjectMother {
         val issuer = "keyForIssuer"
         issuerShortNameValidatedTokenMap[issuer] = token
         val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
-        return OIDCValidationContextPrincipal(context)
+        return TokenValidationContextPrincipal(context)
     }
 
-    fun createPrincipalForIdPorten(ident: String, innloggingsnivaa: Int): OIDCValidationContextPrincipal {
+    fun createPrincipalForIdPorten(ident: String, innloggingsnivaa: Int): TokenValidationContextPrincipal {
         val key: Key = Keys.secretKeyFor(SignatureAlgorithm.HS256)
         val inTwoMinutes = Date(Instant.now().plusSeconds(60).toEpochMilli())
         val expiredJws = Jwts.builder()
@@ -51,7 +51,7 @@ object OIDCValidationContextPrincipalObjectMother {
         val issuer = "keyForIssuer"
         issuerShortNameValidatedTokenMap[issuer] = token
         val context = TokenValidationContext(issuerShortNameValidatedTokenMap)
-        return OIDCValidationContextPrincipal(context)
+        return TokenValidationContextPrincipal(context)
     }
 
 }


### PR DESCRIPTION
Dobler timeout mot legacy for å unngå feil ved genuine tregheter bakover i systemet. Forbedrer logging av slike feil når de inntreffer. 

Går tilbake til versjon 1.3.0 på token support. Bumper versjon av ktor til 1.3.2. Tar ikke i bruk jitpack og ktor:1.3.2.2, fordi jitpack tydeligvis ikke støtter nested submodules, som gjør at vi ikke finnes f. eks. ktor-logging.