### PR TITLE
Øker socket timeout mot legacy til 30 sekunder, og request timeout til 40 sekunder.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -26,9 +26,9 @@ suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, innlogget
         method = HttpMethod.Get
         header(HttpHeaders.Authorization, innloggetBruker.createAuthenticationHeader())
         timeout {
-            socketTimeoutMillis = 20000
+            socketTimeoutMillis = 30000
             connectTimeoutMillis = 10000
-            requestTimeoutMillis = 35000
+            requestTimeoutMillis = 40000
         }
     }
 }


### PR DESCRIPTION
Øker socket timeout enda en gang for å forhindre tidlig brudd av forbindelsen mot legacy i tilfeller der det til slutt ville kommet et gyldig svar fra legacy.