### PR TITLE
PB-458. Forenkle oppdatering av avhengigheter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-/.gradle
-/.idea
-/out
-/build
+.gradle
+.idea
+out
+build
 *.iml
 *.ipr
 *.iws

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,14 +87,11 @@ tasks {
     }
 
     register("runServer", JavaExec::class) {
-        environment("LEGACY_API_URL", "http://localhost:8090/person/dittnav-legacy-api")
-        environment("EVENT_HANDLER_URL", "http://localhost:8092")
-        environment("CORS_ALLOWED_ORIGINS", "localhost:9002")
-
-        environment("OIDC_ISSUER", "http://localhost:9000")
-        environment("OIDC_DISCOVERY_URL", "http://localhost:9000/.well-known/openid-configuration")
-        environment("OIDC_ACCEPTED_AUDIENCE", "stubOidcClient")
-        environment("OIDC_CLAIM_CONTAINING_THE_IDENTITY", "pid")
+        println("Setting default environment variables for running with DittNAV docker-compose")
+        DockerComposeDefaults.environomentVariables.forEach { (name, value) ->
+            println("Setting the environment variable $name")
+            environment(name, value)
+        }
 
         main = application.mainClassName
         classpath = sourceSets["main"].runtimeClasspath

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,30 +1,10 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val prometheusVersion = "0.8.1"
-val ktorVersion = "1.3.2"
-val logstashVersion = 5.2
-val logbackVersion = "1.2.3"
-val kotlinVersion = "1.3.50"
-val jacksonVersion = "2.9.9"
-val spekVersion = "2.0.6"
-val mockKVersion = "1.9.3"
-val assertJVersion = "3.12.2"
-val junitVersion = "5.4.1"
-val kluentVersion = "1.56"
-val tokensupportVersion = "1.3.0"
-val kotlinxCoroutinesVersion = "1.3.3"
-val kotlinxHtmlVersion = "0.6.12"
-val jjwtVersion = "0.11.0"
-val bcproVersion = "1.64"
-
 plugins {
     // Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.
-    val kotlinVersion = "1.3.50"
-    kotlin("jvm").version(kotlinVersion)
-    kotlin("plugin.allopen").version(kotlinVersion)
-
-    id("org.flywaydb.flyway") version ("5.2.4")
+    kotlin("jvm").version(Kotlin.version)
+    kotlin("plugin.allopen").version(Kotlin.version)
 
     // Apply the application plugin to add support for building a CLI application.
     application
@@ -38,44 +18,44 @@ repositories {
     // Use jcenter for resolving your dependencies.
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
-    maven("http://packages.confluent.io/maven")
+    maven("https://packages.confluent.io/maven")
     mavenLocal()
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    compile("no.nav.security:token-validation-ktor:$tokensupportVersion")
-    compile("io.prometheus:simpleclient_common:$prometheusVersion")
-    compile("io.prometheus:simpleclient_hotspot:$prometheusVersion")
-    compile("io.prometheus:simpleclient_logback:$prometheusVersion")
-    compile("io.ktor:ktor-server-netty:$ktorVersion")
-    compile("io.ktor:ktor-auth:$ktorVersion")
-    compile("io.ktor:ktor-auth-jwt:$ktorVersion")
-    compile("io.ktor:ktor-client-apache:$ktorVersion")
-    compile("io.ktor:ktor-client-json:$ktorVersion")
-    compile("io.ktor:ktor-client-serialization-jvm:$ktorVersion")
-    compile("io.ktor:ktor-jackson:$ktorVersion")
-    compile("io.ktor:ktor-client-jackson:$ktorVersion")
-    compile("io.ktor:ktor-html-builder:$ktorVersion")
-    compile("io.ktor:ktor-client-logging:$ktorVersion")
-    compile("io.ktor:ktor-client-logging-jvm:$ktorVersion")
-    compile("ch.qos.logback:logback-classic:$logbackVersion")
-    compile("net.logstash.logback:logstash-logback-encoder:$logstashVersion")
-    compile("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    compile("org.jetbrains.kotlinx:kotlinx-html-jvm:${kotlinxHtmlVersion}")
-    testCompile("org.junit.jupiter:junit-jupiter-api:$junitVersion")
-    testCompile(kotlin("test-junit5"))
-    testCompile("io.ktor:ktor-client-mock:$ktorVersion")
-    testCompile("io.ktor:ktor-client-mock-jvm:$ktorVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    testImplementation("org.amshove.kluent:kluent:$kluentVersion")
-    testImplementation("io.mockk:mockk:$mockKVersion")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
-    testCompile("io.jsonwebtoken:jjwt-api:$jjwtVersion")
-    testRuntime("io.jsonwebtoken:jjwt-impl:$jjwtVersion")
-    testRuntime("io.jsonwebtoken:jjwt-jackson:$jjwtVersion")
-    testRuntime("org.bouncycastle:bcprov-jdk15on:$bcproVersion")
+    implementation(Kotlinx.coroutines)
+    implementation(NAV.tokenValidatorKtor)
+    implementation(Prometheus.common)
+    implementation(Prometheus.hotspot)
+    implementation(Prometheus.logback)
+
+    implementation(Ktor.serverNetty)
+    implementation(Ktor.auth)
+    implementation(Ktor.authJwt)
+    implementation(Ktor.clientApache)
+    implementation(Ktor.clientJson)
+    implementation(Ktor.clientSerializationJvm)
+    implementation(Ktor.jackson)
+    implementation(Ktor.clientJackson)
+    implementation(Ktor.htmlBuilder)
+    implementation(Ktor.clientLogging)
+    implementation(Ktor.clientLoggingJvm)
+
+    implementation(Logback.classic)
+    implementation(Logstash.logbackEncoder)
+
+    implementation(Jackson.dataTypeJsr310)
+    implementation(Kotlinx.htmlJvm)
+    testImplementation(Junit.api)
+    testImplementation(Ktor.clientMock)
+    testImplementation(Ktor.clientMockJvm)
+    testImplementation(Kluent.kluent)
+    testImplementation(Mockk.mockk)
+    testImplementation(Jjwt.api)
+    testRuntimeOnly(Junit.engine)
+    testRuntimeOnly(Jjwt.impl)
+    testRuntimeOnly(Jjwt.jackson)
+    testRuntimeOnly(Bouncycastle.bcprovJdk15on)
 }
 
 application {
@@ -84,11 +64,19 @@ application {
 
 tasks {
     withType<Jar> {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE // Tillater ikke duplikater i jar-fila, slik som kreves for å være kompatible med Gradle 7.
         manifest {
             attributes["Main-Class"] = application.mainClassName
         }
-
-        from(configurations.runtime.get().map { if (it.isDirectory) it else zipTree(it) })
+        from(sourceSets.main.get().output)
+        dependsOn(configurations.runtimeClasspath)
+        from({
+            configurations.runtimeClasspath.get().filter { file ->
+                file.name.endsWith("jar")
+            }.map { fileToAddToZip ->
+                zipTree(fileToAddToZip)
+            }
+        })
     }
 
     withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,39 +23,38 @@ repositories {
 }
 
 dependencies {
+    implementation(Jackson.dataTypeJsr310)
     implementation(Kotlinx.coroutines)
+    implementation(Kotlinx.htmlJvm)
+    implementation(Ktor.auth)
+    implementation(Ktor.authJwt)
+    implementation(Ktor.clientApache)
+    implementation(Ktor.clientJackson)
+    implementation(Ktor.clientJson)
+    implementation(Ktor.clientLogging)
+    implementation(Ktor.clientLoggingJvm)
+    implementation(Ktor.clientSerializationJvm)
+    implementation(Ktor.htmlBuilder)
+    implementation(Ktor.jackson)
+    implementation(Ktor.serverNetty)
+    implementation(Logback.classic)
+    implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.logback)
 
-    implementation(Ktor.serverNetty)
-    implementation(Ktor.auth)
-    implementation(Ktor.authJwt)
-    implementation(Ktor.clientApache)
-    implementation(Ktor.clientJson)
-    implementation(Ktor.clientSerializationJvm)
-    implementation(Ktor.jackson)
-    implementation(Ktor.clientJackson)
-    implementation(Ktor.htmlBuilder)
-    implementation(Ktor.clientLogging)
-    implementation(Ktor.clientLoggingJvm)
-
-    implementation(Logback.classic)
-    implementation(Logstash.logbackEncoder)
-
-    implementation(Jackson.dataTypeJsr310)
-    implementation(Kotlinx.htmlJvm)
     testImplementation(Junit.api)
     testImplementation(Ktor.clientMock)
     testImplementation(Ktor.clientMockJvm)
     testImplementation(Kluent.kluent)
     testImplementation(Mockk.mockk)
     testImplementation(Jjwt.api)
-    testRuntimeOnly(Junit.engine)
+
+    testRuntimeOnly(Bouncycastle.bcprovJdk15on)
     testRuntimeOnly(Jjwt.impl)
     testRuntimeOnly(Jjwt.jackson)
-    testRuntimeOnly(Bouncycastle.bcprovJdk15on)
+    testRuntimeOnly(Junit.engine)
 }
 
 application {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.08.27-12.41-ec847a68d5e0"
+val dittNavDependenciesVersion = "2020.08.27-17.07-d653e3deee18"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    jcenter()
+    maven("https://jitpack.io")
+}
+
+val dittNavDependenciesVersion = "2020.08.27-12.41-ec847a68d5e0"
+
+dependencies {
+    implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,6 @@
+/*
+Fixes annoying gradle idea plugin bug. The idea gradle plugin expects unique root project name for buildSrc in gradle composite builds
+https://github.com/gradle/gradle/issues/8920
+ */
+
+rootProject.name = rootProject.projectDir.parentFile.name + "-buildSrc"


### PR DESCRIPTION
Nytt ift de andre appene er at jeg har flyttet miljøvariablene for å kjøre appen lokalt, mot docker-compose, ut i dittnav-dependencies slik at disse kan gjenbrukes i alle appene våre.

For å flytte hele setting av miljøvariabler ut så ser det ut som at man må lage et eget gradle-plugin, det tok jeg meg ikke tid til nå. På sikt kan det være interessant å lage et slik plugin, slik at vi kan flytte ut kode som vi typisk bruker i alle bygg-filene våre. F.eks. det med å produser en kjørbar jar-fil.