### PR TITLE
Senker loggnivået på request-er som filer grunnet utløpt token

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBruker.kt
@@ -1,11 +1,17 @@
 package no.nav.personbruker.dittnav.api.common
 
+import java.time.Instant
 import java.time.LocalDateTime
+import java.time.ZoneId
 
-data class InnloggetBruker(val ident: String,
-                           val innloggingsnivaa: Int,
-                           val token: String,
-                           val tokenExpirationTime: LocalDateTime) {
+data class InnloggetBruker(
+    val ident: String,
+    val innloggingsnivaa: Int,
+    val token: String,
+    val tokenExpirationTime: LocalDateTime
+) {
+
+    private val oslo = ZoneId.of("Europe/Oslo")
 
     fun createAuthenticationHeader(): String {
         return "Bearer $token"
@@ -13,6 +19,11 @@ data class InnloggetBruker(val ident: String,
 
     override fun toString(): String {
         return "InnloggetBruker(ident='***', innloggingsnivaa=$innloggingsnivaa, token='***', tokenUtlopsdato: $tokenExpirationTime)"
+    }
+
+    fun isTokenExpired(): Boolean {
+        val now = Instant.now().atZone(oslo).toLocalDateTime()
+        return tokenExpirationTime.isBefore(now)
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -24,21 +24,11 @@ object InnloggetBrukerObjectMother {
     }
 
     fun createInnloggetBruker(ident: String, innloggingsnivaa: Int): InnloggetBruker {
-        val jws = Jwts.builder()
-                .setSubject(ident)
-                .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)
-                .setExpiration(Date(System.currentTimeMillis().plus(1000000)))
-                .signWith(key).compact()
-        val token = JwtToken(jws)
-        val expirationTime = token.jwtTokenClaims
-                                                .expirationTime
-                                                .toInstant()
-                                                .atZone(ZoneId.of("Europe/Oslo"))
-                                                .toLocalDateTime()
-        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString, expirationTime)
+        val inTwoMinutes = ZonedDateTime.now().plusMinutes(2)
+        return createInnloggetBrukerWithValidTokenUntil(ident, innloggingsnivaa, inTwoMinutes)
     }
 
-    fun createInnloggetBruker(ident: String, innloggingsnivaa: Int, tokensUtlopstidspunkt: ZonedDateTime): InnloggetBruker {
+    fun createInnloggetBrukerWithValidTokenUntil(ident: String, innloggingsnivaa: Int, tokensUtlopstidspunkt: ZonedDateTime): InnloggetBruker {
         val jws = Jwts.builder()
                 .setSubject(ident)
                 .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerObjectMother.kt
@@ -6,6 +6,7 @@ import io.jsonwebtoken.security.Keys
 import no.nav.security.token.support.core.jwt.JwtToken
 import java.security.Key
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.*
 
 object InnloggetBrukerObjectMother {
@@ -27,6 +28,21 @@ object InnloggetBrukerObjectMother {
                 .setSubject(ident)
                 .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)
                 .setExpiration(Date(System.currentTimeMillis().plus(1000000)))
+                .signWith(key).compact()
+        val token = JwtToken(jws)
+        val expirationTime = token.jwtTokenClaims
+                                                .expirationTime
+                                                .toInstant()
+                                                .atZone(ZoneId.of("Europe/Oslo"))
+                                                .toLocalDateTime()
+        return InnloggetBruker(ident, innloggingsnivaa, token.tokenAsString, expirationTime)
+    }
+
+    fun createInnloggetBruker(ident: String, innloggingsnivaa: Int, tokensUtlopstidspunkt: ZonedDateTime): InnloggetBruker {
+        val jws = Jwts.builder()
+                .setSubject(ident)
+                .addClaims(mutableMapOf(Pair("acr", "Level$innloggingsnivaa")) as Map<String, Any>?)
+                .setExpiration(Date.from(tokensUtlopstidspunkt.toInstant()))
                 .signWith(key).compact()
         val token = JwtToken(jws)
         val expirationTime = token.jwtTokenClaims

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
@@ -5,6 +5,7 @@ import org.amshove.kluent.`should contain`
 import org.amshove.kluent.`should not contain`
 import org.amshove.kluent.shouldNotBeNullOrBlank
 import org.junit.jupiter.api.Test
+import java.time.ZonedDateTime
 
 internal class InnloggetBrukerTest {
 
@@ -38,6 +39,22 @@ internal class InnloggetBrukerTest {
         outputOfToString `should contain` (innloggetBruker.innloggingsnivaa.toString())
         outputOfToString `should not contain` (innloggetBruker.ident)
         outputOfToString `should not contain` (innloggetBruker.token)
+    }
+
+    @Test
+    fun `should return false for users with expired token`() {
+        val inThePast = ZonedDateTime.now().minusSeconds(120)
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBruker("123", 4, inThePast)
+
+        bruker.isTokenExpired() `should be equal to` true
+    }
+
+    @Test
+    fun `should return true for users with valid token`() {
+        val inTheFuture = ZonedDateTime.now().plusSeconds(120)
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBruker("123", 4, inTheFuture)
+
+        bruker.isTokenExpired() `should be equal to` false
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/common/InnloggetBrukerTest.kt
@@ -44,7 +44,7 @@ internal class InnloggetBrukerTest {
     @Test
     fun `should return false for users with expired token`() {
         val inThePast = ZonedDateTime.now().minusSeconds(120)
-        val bruker = InnloggetBrukerObjectMother.createInnloggetBruker("123", 4, inThePast)
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBrukerWithValidTokenUntil("123", 4, inThePast)
 
         bruker.isTokenExpired() `should be equal to` true
     }
@@ -52,7 +52,7 @@ internal class InnloggetBrukerTest {
     @Test
     fun `should return true for users with valid token`() {
         val inTheFuture = ZonedDateTime.now().plusSeconds(120)
-        val bruker = InnloggetBrukerObjectMother.createInnloggetBruker("123", 4, inTheFuture)
+        val bruker = InnloggetBrukerObjectMother.createInnloggetBrukerWithValidTokenUntil("123", 4, inTheFuture)
 
         bruker.isTokenExpired() `should be equal to` false
     }


### PR DESCRIPTION
Ønsker at det skal komme færre slack-varsler om at kall har feilet grunnet http-401 i tilfeller hvor token-et alt er utløpt.

Et alternativ kan være å heller stoppe disse request-ene på vei inn til backend-en, i tilfeller hvor det er stor sannsynlighet for at token-et kommer til å utløpe før det kommer svar.