### PR TITLE
PB-490. Gjort det mulig å hente varsler samtidig som beskjeder i dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ repositories {
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
     maven("https://packages.confluent.io/maven")
+    maven("https://jitpack.io")
     mavenLocal()
 }
 
@@ -50,6 +51,7 @@ dependencies {
     testImplementation(Kluent.kluent)
     testImplementation(Mockk.mockk)
     testImplementation(Jjwt.api)
+    testImplementation(DittNAV.Common.test)
 
     testRuntimeOnly(Bouncycastle.bcprovJdk15on)
     testRuntimeOnly(Jjwt.impl)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2020.08.27-17.07-d653e3deee18"
+val dittNavDependenciesVersion = "2020.09.17-14.51-192ef2f686b9"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedDTO.kt
@@ -11,7 +11,8 @@ data class BeskjedDTO(
         val link: String,
         val produsent: String?,
         val sistOppdatert: ZonedDateTime,
-        val sikkerhetsnivaa: Int
+        val sikkerhetsnivaa: Int,
+        val aktiv: Boolean
 ) {
     constructor(
             eventTidspunkt: ZonedDateTime,
@@ -20,7 +21,8 @@ data class BeskjedDTO(
             link: String,
             produsent: String?,
             sistOppdatert: ZonedDateTime,
-            sikkerhetsnivaa: Int
+            sikkerhetsnivaa: Int,
+            aktiv: Boolean
     ) : this(
             null,
             eventTidspunkt,
@@ -29,6 +31,7 @@ data class BeskjedDTO(
             link,
             produsent,
             sistOppdatert,
-            sikkerhetsnivaa
+            sikkerhetsnivaa,
+            aktiv
     )
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/MergeBeskjedMedVarselService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/MergeBeskjedMedVarselService.kt
@@ -1,0 +1,65 @@
+package no.nav.personbruker.dittnav.api.beskjed
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.withContext
+import no.nav.personbruker.dittnav.api.common.ConsumeEventException
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
+import no.nav.personbruker.dittnav.api.varsel.VarselService
+import org.slf4j.LoggerFactory
+
+class MergeBeskjedMedVarselService(
+    private val beskjedService: BeskjedService,
+    private val varselService: VarselService
+) {
+
+    private val log = LoggerFactory.getLogger(MergeBeskjedMedVarselService::class.java)
+
+    suspend fun getActiveEvents(innloggetBruker: InnloggetBruker): List<BeskjedDTO> {
+        return try {
+            withContext(Dispatchers.IO) {
+                val beskjeder = async {
+                    beskjedService.getActiveBeskjedEvents(innloggetBruker)
+                }
+
+                val varslerSomBeskjed = async {
+                    varselService.getActiveVarselEvents(innloggetBruker)
+                }
+
+                val allActive = mutableListOf<BeskjedDTO>()
+                allActive.addAll(beskjeder.await())
+                allActive.addAll(varslerSomBeskjed.await())
+                allActive
+            }
+        } catch (e: Exception) {
+            throw ConsumeEventException(
+                "Uventet feil ved sammenslåing av aktive beskjeder og varsler. Minst en av kildene feilet.", e
+            )
+        }
+    }
+
+    suspend fun getInactiveEvents(innloggetBruker: InnloggetBruker): List<BeskjedDTO> {
+        return try {
+            withContext(Dispatchers.IO) {
+                val beskjeder = async {
+                    beskjedService.getInactiveBeskjedEvents(innloggetBruker)
+                }
+
+                val varslerSomBeskjed = async {
+                    varselService.getInactiveVarselEvents(innloggetBruker)
+                }
+
+                val allInactive = mutableListOf<BeskjedDTO>()
+                allInactive.addAll(beskjeder.await())
+                allInactive.addAll(varslerSomBeskjed.await())
+
+                return@withContext allInactive
+            }
+        } catch (e: Exception) {
+            throw ConsumeEventException(
+                "Uventet feil ved sammenslåing av inaktive beskjeder og varsler. Minst en av kildene feilet.", e
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -24,8 +24,6 @@ fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: 
     }
 
     get("/beskjed/inaktiv") {
-        log.info("Kjører i et dev-miljø, aktiverer grensesnittet for vasler sammen med beskjeder.")
-
         try {
             val beskjedEvents = beskjedService.getInactiveBeskjedEvents(innloggetBruker)
             call.respond(HttpStatusCode.OK, beskjedEvents)
@@ -36,6 +34,8 @@ fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: 
     }
 
     if (isRunningInDev()) {
+        log.info("Kjører i et dev-miljø, aktiverer grensesnittet for vasler sammen med beskjeder.")
+
         get("/beskjed/merged") {
             try {
                 val events = mergeBeskjedMedVarselService.getActiveEvents(innloggetBruker)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -6,6 +6,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
+import no.nav.personbruker.dittnav.api.config.isRunningInDev
 import org.slf4j.LoggerFactory
 
 fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: MergeBeskjedMedVarselService) {
@@ -23,6 +24,8 @@ fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: 
     }
 
     get("/beskjed/inaktiv") {
+        log.info("Kjører i et dev-miljø, aktiverer grensesnittet for vasler sammen med beskjeder.")
+
         try {
             val beskjedEvents = beskjedService.getInactiveBeskjedEvents(innloggetBruker)
             call.respond(HttpStatusCode.OK, beskjedEvents)
@@ -32,23 +35,25 @@ fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: 
         }
     }
 
-    get("/beskjed/merged") {
-        try {
-            val events = mergeBeskjedMedVarselService.getActiveEvents(innloggetBruker)
-            call.respond(HttpStatusCode.OK, events)
+    if (isRunningInDev()) {
+        get("/beskjed/merged") {
+            try {
+                val events = mergeBeskjedMedVarselService.getActiveEvents(innloggetBruker)
+                call.respond(HttpStatusCode.OK, events)
 
-        } catch (exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
-    }
 
-    get("/beskjed/merged/inaktiv") {
-        try {
-            val events = mergeBeskjedMedVarselService.getInactiveEvents(innloggetBruker)
-            call.respond(HttpStatusCode.OK, events)
+        get("/beskjed/merged/inaktiv") {
+            try {
+                val events = mergeBeskjedMedVarselService.getInactiveEvents(innloggetBruker)
+                call.respond(HttpStatusCode.OK, events)
 
-        } catch (exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -1,15 +1,14 @@
 package no.nav.personbruker.dittnav.api.beskjed
 
-import io.ktor.application.call
-import io.ktor.http.HttpStatusCode
-import io.ktor.response.respond
-import io.ktor.routing.Route
-import io.ktor.routing.get
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
 import org.slf4j.LoggerFactory
 
-fun Route.beskjed(beskjedService: BeskjedService) {
+fun Route.beskjed(beskjedService: BeskjedService, mergeBeskjedMedVarselService: MergeBeskjedMedVarselService) {
 
     val log = LoggerFactory.getLogger(BeskjedService::class.java)
 
@@ -17,7 +16,8 @@ fun Route.beskjed(beskjedService: BeskjedService) {
         try {
             val beskjedEvents = beskjedService.getActiveBeskjedEvents(innloggetBruker)
             call.respond(HttpStatusCode.OK, beskjedEvents)
-        } catch(exception: Exception) {
+
+        } catch (exception: Exception) {
             respondWithError(call, log, exception)
         }
     }
@@ -26,8 +26,30 @@ fun Route.beskjed(beskjedService: BeskjedService) {
         try {
             val beskjedEvents = beskjedService.getInactiveBeskjedEvents(innloggetBruker)
             call.respond(HttpStatusCode.OK, beskjedEvents)
-        } catch(exception: Exception) {
+
+        } catch (exception: Exception) {
             respondWithError(call, log, exception)
         }
     }
+
+    get("/beskjed/merged") {
+        try {
+            val events = mergeBeskjedMedVarselService.getActiveEvents(innloggetBruker)
+            call.respond(HttpStatusCode.OK, events)
+
+        } catch (exception: Exception) {
+            respondWithError(call, log, exception)
+        }
+    }
+
+    get("/beskjed/merged/inaktiv") {
+        try {
+            val events = mergeBeskjedMedVarselService.getInactiveEvents(innloggetBruker)
+            call.respond(HttpStatusCode.OK, events)
+
+        } catch (exception: Exception) {
+            respondWithError(call, log, exception)
+        }
+    }
+
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedTransformer.kt
@@ -10,12 +10,13 @@ fun toBeskjedDTO(beskjed: Beskjed): BeskjedDTO =
                     link = it.link,
                     produsent = it.produsent,
                     sistOppdatert = it.sistOppdatert,
-                    sikkerhetsnivaa = it.sikkerhetsnivaa
+                    sikkerhetsnivaa = it.sikkerhetsnivaa,
+                    aktiv = it.aktiv
             )
         }
 
 fun toMaskedBeskjedDTO(beskjed: Beskjed): BeskjedDTO =
         beskjed.let {
-            var maskedBeskjedDTO = toBeskjedDTO(beskjed)
+            val maskedBeskjedDTO = toBeskjedDTO(beskjed)
             return maskedBeskjedDTO.copy(tekst = "***", link = "***", produsent = "***")
         }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/JsonConfig.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/JsonConfig.kt
@@ -3,7 +3,8 @@ package no.nav.personbruker.dittnav.api.config
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import io.ktor.client.features.json.JacksonSerializer
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import io.ktor.client.features.json.*
 
 fun buildJsonSerializer(): JacksonSerializer {
     return JacksonSerializer {
@@ -12,6 +13,7 @@ fun buildJsonSerializer(): JacksonSerializer {
 }
 
 fun ObjectMapper.enableDittNavJsonConfig() {
+    registerKotlinModule()
     registerModule(JavaTimeModule())
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -12,6 +12,7 @@ import io.ktor.util.pipeline.*
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedConsumer
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
+import no.nav.personbruker.dittnav.api.beskjed.MergeBeskjedMedVarselService
 import no.nav.personbruker.dittnav.api.beskjed.beskjed
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.BrukernotifikasjonConsumer
 import no.nav.personbruker.dittnav.api.brukernotifikasjon.BrukernotifikasjonService
@@ -57,6 +58,7 @@ fun Application.mainModule() {
     val innboksService = InnboksService(innboksConsumer)
     val brukernotifikasjonService = BrukernotifikasjonService(brukernotifikasjonConsumer)
     val varselService = VarselService(varselConsumer)
+    val mergeBeskjedMedVarselService = MergeBeskjedMedVarselService(beskjedService, varselService)
 
     install(DefaultHeaders)
 
@@ -83,7 +85,7 @@ fun Application.mainModule() {
         authenticate {
             legacyApi(legacyConsumer)
             oppgave(oppgaveService)
-            beskjed(beskjedService)
+            beskjed(beskjedService, mergeBeskjedMedVarselService)
             if(isRunningInDev()) {
                 log.info("Kjører i et dev-miljø, aktiverer grensesnittet for vasler.")
                 varsel(varselService)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -1,18 +1,14 @@
 package no.nav.personbruker.dittnav.api.config
 
 import io.ktor.application.*
-import io.ktor.auth.Authentication
-import io.ktor.auth.authenticate
-import io.ktor.auth.authentication
-import io.ktor.client.HttpClient
-import io.ktor.features.CORS
-import io.ktor.features.ContentNegotiation
-import io.ktor.features.DefaultHeaders
-import io.ktor.http.HttpHeaders
-import io.ktor.jackson.jackson
-import io.ktor.routing.routing
-import io.ktor.util.KtorExperimentalAPI
-import io.ktor.util.pipeline.PipelineContext
+import io.ktor.auth.*
+import io.ktor.client.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.jackson.*
+import io.ktor.routing.*
+import io.ktor.util.*
+import io.ktor.util.pipeline.*
 import io.prometheus.client.hotspot.DefaultExports
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedConsumer
 import no.nav.personbruker.dittnav.api.beskjed.BeskjedService
@@ -36,6 +32,7 @@ import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
 import no.nav.personbruker.dittnav.api.oppgave.oppgave
 import no.nav.personbruker.dittnav.api.varsel.VarselConsumer
 import no.nav.personbruker.dittnav.api.varsel.VarselService
+import no.nav.personbruker.dittnav.api.varsel.varsel
 import no.nav.security.token.support.ktor.tokenValidationSupport
 
 @KtorExperimentalAPI
@@ -87,6 +84,10 @@ fun Application.mainModule() {
             legacyApi(legacyConsumer)
             oppgave(oppgaveService)
             beskjed(beskjedService)
+            if(isRunningInDev()) {
+                log.info("Kjører i et dev-miljø, aktiverer grensesnittet for vasler.")
+                varsel(varselService)
+            }
             innboks(innboksService)
             brukernotifikasjoner(brukernotifikasjonService)
             authenticationCheck()
@@ -105,3 +106,11 @@ private fun Application.configureShutdownHook(httpClient: HttpClient) {
 
 val PipelineContext<Unit, ApplicationCall>.innloggetBruker: InnloggetBruker
     get() = InnloggetBrukerFactory.createNewInnloggetBruker(call.authentication.principal())
+
+fun isRunningInDev(clusterName: String? = System.getenv("NAIS_CLUSTER_NAME")): Boolean {
+    var runningInDev = true
+    if (clusterName != null && clusterName == "prod-sbs") {
+        runningInDev = false
+    }
+    return runningInDev
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -34,6 +34,8 @@ import no.nav.personbruker.dittnav.api.legacy.legacyApi
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveConsumer
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
 import no.nav.personbruker.dittnav.api.oppgave.oppgave
+import no.nav.personbruker.dittnav.api.varsel.VarselConsumer
+import no.nav.personbruker.dittnav.api.varsel.VarselService
 import no.nav.security.token.support.ktor.tokenValidationSupport
 
 @KtorExperimentalAPI
@@ -49,6 +51,7 @@ fun Application.mainModule() {
     val beskjedConsumer = BeskjedConsumer(httpClient, environment.eventHandlerURL)
     val innboksConsumer = InnboksConsumer(httpClient, environment.eventHandlerURL)
     val brukernotifikasjonConsumer = BrukernotifikasjonConsumer(httpClient, environment.eventHandlerURL)
+    val varselConsumer = VarselConsumer(httpClient, environment.legacyApiURL)
 
     val doneProducer = DoneProducer(httpClient, environment.eventHandlerURL)
 
@@ -56,6 +59,7 @@ fun Application.mainModule() {
     val beskjedService = BeskjedService(beskjedConsumer)
     val innboksService = InnboksService(innboksConsumer)
     val brukernotifikasjonService = BrukernotifikasjonService(brukernotifikasjonConsumer)
+    val varselService = VarselService(varselConsumer)
 
     install(DefaultHeaders)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/Varsel.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/Varsel.kt
@@ -1,0 +1,27 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import java.time.LocalDate
+
+data class Varsel(
+    val id: Long,
+    val aktoerID: String,
+    val url: String,
+    val varseltekst: String,
+    val varselId: String,
+    val meldingsType: String,
+    val datoOpprettet: LocalDate,
+    val datoLest: LocalDate?
+) {
+    override fun toString(): String {
+        return "Varsel(" +
+                "id=$id, " +
+                "aktoerID=***, " +
+                "url=***, " +
+                "varseltekst=***, " +
+                "varselId=$varselId, " +
+                "meldingsType=$meldingsType, " +
+                "datoOpprettet=$datoOpprettet, " +
+                "datoLest=$datoLest)"
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/Varsel.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/Varsel.kt
@@ -1,6 +1,6 @@
 package no.nav.personbruker.dittnav.api.varsel
 
-import java.time.LocalDate
+import java.time.ZonedDateTime
 
 data class Varsel(
     val id: Long,
@@ -9,8 +9,8 @@ data class Varsel(
     val varseltekst: String,
     val varselId: String,
     val meldingsType: String,
-    val datoOpprettet: LocalDate,
-    val datoLest: LocalDate?
+    val datoOpprettet: ZonedDateTime,
+    val datoLest: ZonedDateTime?
 ) {
     override fun toString(): String {
         return "Varsel(" +

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumer.kt
@@ -1,0 +1,23 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import io.ktor.client.*
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
+import no.nav.personbruker.dittnav.api.config.get
+import java.net.URL
+
+class VarselConsumer(
+    private val client: HttpClient,
+    private val legacyApiBaseURL: URL,
+    private val pathToEndpoint: URL = URL("$legacyApiBaseURL/varselinnboks")
+) {
+
+    suspend fun getSisteVarsler(innloggetBruker: InnloggetBruker): List<Varsel> {
+        val completePathToEndpoint = URL("$pathToEndpoint/siste")
+        return getSisteVarsler(innloggetBruker, completePathToEndpoint)
+    }
+
+    private suspend fun getSisteVarsler(innloggetBruker: InnloggetBruker, completePathToEndpoint: URL): List<Varsel> {
+        return client.get(completePathToEndpoint, innloggetBruker)
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselService.kt
@@ -1,0 +1,44 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import no.nav.personbruker.dittnav.api.beskjed.BeskjedDTO
+import no.nav.personbruker.dittnav.api.common.ConsumeEventException
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
+
+class VarselService(private val varselConsumer: VarselConsumer) {
+
+    suspend fun getActiveVarselEvents(innloggetBruker: InnloggetBruker): List<BeskjedDTO> {
+        return getVarselEvents(innloggetBruker) {
+            varselConsumer.getSisteVarsler(it).filter { varsel -> varsel.datoLest == null }
+        }
+    }
+
+    suspend fun getInactiveVarselEvents(innloggetBruker: InnloggetBruker): List<BeskjedDTO> {
+        return getVarselEvents(innloggetBruker) {
+            varselConsumer.getSisteVarsler(it).filter { varsel -> varsel.datoLest != null }
+        }
+    }
+
+    private suspend fun getVarselEvents(
+        innloggetBruker: InnloggetBruker,
+        getEvents: suspend (InnloggetBruker) -> List<Varsel>
+    ): List<BeskjedDTO> {
+        return try {
+            val externalEvents = getEvents(innloggetBruker)
+            externalEvents.map { varsel -> transformToDTO(varsel, innloggetBruker) }
+        } catch (exception: Exception) {
+            throw ConsumeEventException("Klarte ikke hente eventer av type Varsel", exception)
+        }
+    }
+
+    private fun transformToDTO(varsel: Varsel, innloggetBruker: InnloggetBruker): BeskjedDTO {
+        return if (innloggetBrukerIsAllowedToViewAllDataInEvent(innloggetBruker)) {
+            toVarselDTO(varsel)
+        } else {
+            toMaskedVarselDTO(varsel)
+        }
+    }
+
+    private fun innloggetBrukerIsAllowedToViewAllDataInEvent(innloggetBruker: InnloggetBruker): Boolean {
+        return innloggetBruker.innloggingsnivaa >= 4
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselService.kt
@@ -24,21 +24,10 @@ class VarselService(private val varselConsumer: VarselConsumer) {
     ): List<BeskjedDTO> {
         return try {
             val externalEvents = getEvents(innloggetBruker)
-            externalEvents.map { varsel -> transformToDTO(varsel, innloggetBruker) }
+            externalEvents.map { varsel -> toVarselDTO(varsel) }
         } catch (exception: Exception) {
             throw ConsumeEventException("Klarte ikke hente eventer av type Varsel", exception)
         }
     }
 
-    private fun transformToDTO(varsel: Varsel, innloggetBruker: InnloggetBruker): BeskjedDTO {
-        return if (innloggetBrukerIsAllowedToViewAllDataInEvent(innloggetBruker)) {
-            toVarselDTO(varsel)
-        } else {
-            toMaskedVarselDTO(varsel)
-        }
-    }
-
-    private fun innloggetBrukerIsAllowedToViewAllDataInEvent(innloggetBruker: InnloggetBruker): Boolean {
-        return innloggetBruker.innloggingsnivaa >= 4
-    }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselApi.kt
@@ -1,0 +1,33 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import io.ktor.application.call
+import io.ktor.http.HttpStatusCode
+import io.ktor.response.respond
+import io.ktor.routing.Route
+import io.ktor.routing.get
+import no.nav.personbruker.dittnav.api.common.respondWithError
+import no.nav.personbruker.dittnav.api.config.innloggetBruker
+import org.slf4j.LoggerFactory
+
+fun Route.varsel(varselService: VarselService) {
+
+    val log = LoggerFactory.getLogger(VarselService::class.java)
+
+    get("/varsel") {
+        try {
+            val varselEvents = varselService.getActiveVarselEvents(innloggetBruker)
+            call.respond(HttpStatusCode.OK, varselEvents)
+        } catch(exception: Exception) {
+            respondWithError(call, log, exception)
+        }
+    }
+
+    get("/varsel/inaktiv") {
+        try {
+            val varselEvents = varselService.getInactiveVarselEvents(innloggetBruker)
+            call.respond(HttpStatusCode.OK, varselEvents)
+        } catch(exception: Exception) {
+            respondWithError(call, log, exception)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
@@ -9,23 +9,19 @@ fun toVarselDTO(externalVarsel: Varsel): BeskjedDTO =
     externalVarsel.let { varsel ->
         BeskjedDTO(
             uid = "${varsel.id}",
-            eventTidspunkt = varsel.datoOpprettet.toZonedDateTime(),
+            eventTidspunkt = varsel.datoOpprettet,
             eventId = varsel.varselId,
             tekst = cropTextIfOverMaxLengthOfBeskjed(varsel.varseltekst),
             link = varsel.url,
             produsent = "varselinnboks",
-            sistOppdatert = chooseSisteOppdatert(varsel),
-            sikkerhetsnivaa = 4
+            sistOppdatert = chooseSistOppdatert(varsel),
+            sikkerhetsnivaa = 3,
+            aktiv = varsel.datoLest == null
         )
     }
 
-private fun chooseSisteOppdatert(varsel: Varsel): ZonedDateTime {
-    return if (varsel.datoLest != null) {
-        varsel.datoLest.toZonedDateTime()
-
-    } else {
-        varsel.datoOpprettet.toZonedDateTime()
-    }
+private fun chooseSistOppdatert(varsel: Varsel): ZonedDateTime {
+    return varsel.datoLest ?: varsel.datoOpprettet
 }
 
 private fun cropTextIfOverMaxLengthOfBeskjed(text: String): String {
@@ -36,12 +32,6 @@ private fun cropTextIfOverMaxLengthOfBeskjed(text: String): String {
         text.substring(0, 150)
     }
 }
-
-fun toMaskedVarselDTO(varsel: Varsel): BeskjedDTO =
-    varsel.let {
-        val maskedVarselDTO = toVarselDTO(varsel)
-        return maskedVarselDTO.copy(tekst = "***", link = "***", produsent = "***")
-    }
 
 fun LocalDate.toZonedDateTime(): ZonedDateTime {
     val zone = ZoneId.of("Europe/Oslo")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
@@ -1,0 +1,50 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import no.nav.personbruker.dittnav.api.beskjed.BeskjedDTO
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+fun toVarselDTO(externalVarsel: Varsel): BeskjedDTO =
+    externalVarsel.let { varsel ->
+        BeskjedDTO(
+            uid = "${varsel.id}",
+            eventTidspunkt = varsel.datoOpprettet.toZonedDateTime(),
+            eventId = varsel.varselId,
+            tekst = cropTextIfOverMaxLengthOfBeskjed(varsel.varseltekst),
+            link = varsel.url,
+            produsent = "varselinnboks",
+            sistOppdatert = chooseSisteOppdatert(varsel),
+            sikkerhetsnivaa = 4
+        )
+    }
+
+private fun chooseSisteOppdatert(varsel: Varsel): ZonedDateTime {
+    return if (varsel.datoLest != null) {
+        varsel.datoLest.toZonedDateTime()
+
+    } else {
+        varsel.datoOpprettet.toZonedDateTime()
+    }
+}
+
+private fun cropTextIfOverMaxLengthOfBeskjed(text: String): String {
+    return if (text.length <= 150) {
+        text
+
+    } else {
+        text.substring(0, 150)
+    }
+}
+
+fun toMaskedVarselDTO(varsel: Varsel): BeskjedDTO =
+    varsel.let {
+        val maskedVarselDTO = toVarselDTO(varsel)
+        return maskedVarselDTO.copy(tekst = "***", link = "***", produsent = "***")
+    }
+
+fun LocalDate.toZonedDateTime(): ZonedDateTime {
+    val zone = ZoneId.of("Europe/Oslo")
+    val instant = atStartOfDay(zone).toInstant()
+    return ZonedDateTime.ofInstant(instant, zone)
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
@@ -28,7 +28,7 @@ class BeskjedConsumerTest {
     val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
-    fun `should call beskjed endpoint on event handler`() {
+    fun `Skal kalle beskjed-endepunktet i event-handler`() {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler { request ->
@@ -51,7 +51,7 @@ class BeskjedConsumerTest {
     }
 
     @Test
-    fun `should get list of active Beskjed`() {
+    fun `Skal mottat en liste over aktive Beskjeder`() {
         val beskjedObject = createBeskjed("1", "1", "1", true)
         val objectMapper = ObjectMapper().apply {
             enableDittNavJsonConfig()
@@ -76,7 +76,7 @@ class BeskjedConsumerTest {
     }
 
     @Test
-    fun `should get list of inactive Beskjed`() {
+    fun `Skal motta en liste over inaktive Beskjeder`() {
         val beskjedObject = createBeskjed("1", "1", "1", false)
         val objectMapper = ObjectMapper().apply {
             enableDittNavJsonConfig()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumerTest.kt
@@ -28,7 +28,7 @@ class BeskjedConsumerTest {
     val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
-    fun `should call information endpoint on event handler`() {
+    fun `should call beskjed endpoint on event handler`() {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler { request ->

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedDtoObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedDtoObjectMother.kt
@@ -1,0 +1,49 @@
+package no.nav.personbruker.dittnav.api.beskjed
+
+import java.time.ZonedDateTime
+
+object BeskjedDtoObjectMother {
+
+    fun createActiveBeskjed(eventId: String): BeskjedDTO {
+        return BeskjedDTO(
+            ZonedDateTime.now().minusDays(3),
+            eventId,
+            "Dummytekst",
+            "https://dummy.url",
+            "dummy-produsent",
+            ZonedDateTime.now().minusDays(3),
+            3,
+            true
+        )
+    }
+
+    fun createNumberOfActiveBeskjed(number: Int, baseEventId: String = "beskjed"): List<BeskjedDTO> {
+        val list = mutableListOf<BeskjedDTO>()
+        for (i in 1..number) {
+            list.add(createActiveBeskjed("$baseEventId-$i"))
+        }
+        return list
+    }
+
+    fun createInactiveBeskjed(eventId: String): BeskjedDTO {
+        return BeskjedDTO(
+            ZonedDateTime.now().minusDays(3),
+            eventId,
+            "Dummytekst",
+            "https://dummy.url",
+            "dummy-produsent",
+            ZonedDateTime.now().minusDays(1),
+            3,
+            false
+        )
+    }
+
+    fun createNumberOfInactiveBeskjed(number: Int, baseEventId: String = "beskjed"): List<BeskjedDTO> {
+        val list = mutableListOf<BeskjedDTO>()
+        for (i in 1..number) {
+            list.add(createInactiveBeskjed("$baseEventId-$i"))
+        }
+        return list
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/MergeBeskjedMedVarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/MergeBeskjedMedVarselServiceTest.kt
@@ -1,0 +1,92 @@
+package no.nav.personbruker.dittnav.api.beskjed
+
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.common.test.`with message containing`
+import no.nav.personbruker.dittnav.api.common.ConsumeEventException
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
+import no.nav.personbruker.dittnav.api.varsel.VarselService
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+internal class MergeBeskjedMedVarselServiceTest {
+
+    private val beskjedService = mockk<BeskjedService>()
+    private val varselService = mockk<VarselService>()
+
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
+
+    @BeforeEach
+    fun init() {
+        clearMocks(beskjedService, varselService)
+    }
+
+    @Test
+    fun `Skal vise aktive beskjeder og varsler sammen`() {
+        val expectedBeskjeder = BeskjedDtoObjectMother.createNumberOfInactiveBeskjed(1)
+        val expectedVarslerAsBeskjed = BeskjedDtoObjectMother.createNumberOfInactiveBeskjed(2, "varsel")
+        coEvery { beskjedService.getActiveBeskjedEvents(any()) } returns expectedBeskjeder
+        coEvery { varselService.getActiveVarselEvents(any()) } returns expectedVarslerAsBeskjed
+
+        val service = MergeBeskjedMedVarselService(beskjedService, varselService)
+
+        val alleAktive = runBlocking {
+            service.getActiveEvents(innloggetBruker)
+        }
+
+        alleAktive.shouldNotBeNull()
+        alleAktive.size `should be` expectedBeskjeder.size + expectedVarslerAsBeskjed.size
+    }
+
+    @Test
+    fun `Skal vise inaktive beskjeder og varsler sammen`() {
+        val expectedBeskjeder = BeskjedDtoObjectMother.createNumberOfInactiveBeskjed(2)
+        val expectedVarslerAsBeskjed = BeskjedDtoObjectMother.createNumberOfInactiveBeskjed(3, "varsel")
+        coEvery { beskjedService.getActiveBeskjedEvents(any()) } returns expectedBeskjeder
+        coEvery { varselService.getActiveVarselEvents(any()) } returns expectedVarslerAsBeskjed
+
+        val service = MergeBeskjedMedVarselService(beskjedService, varselService)
+
+        val alleInaktive = runBlocking {
+            service.getActiveEvents(innloggetBruker)
+        }
+
+        alleInaktive.shouldNotBeNull()
+        alleInaktive.size `should be` expectedBeskjeder.size + expectedVarslerAsBeskjed.size
+    }
+
+    @Test
+    fun `Skal kaste intern exception hvis minst en av kildene for aktive eventer feiler`() {
+        coEvery { beskjedService.getActiveBeskjedEvents(any()) } throws Exception("Simulert feil")
+        coEvery { varselService.getActiveVarselEvents(any()) } returns emptyList()
+
+        val service = MergeBeskjedMedVarselService(beskjedService, varselService)
+
+        invoking {
+            runBlocking {
+                service.getActiveEvents(innloggetBruker)
+            }
+        } `should throw` ConsumeEventException::class `with message containing` "Uventet feil ved sammenslåing av aktive"
+    }
+
+    @Test
+    fun `Skal kaste intern exception hvis minst en av kildene for inaktive eventer feiler`() {
+        coEvery { beskjedService.getActiveBeskjedEvents(any()) } returns emptyList()
+        coEvery { varselService.getActiveVarselEvents(any()) } throws Exception("Simulert feil")
+
+        val service = MergeBeskjedMedVarselService(beskjedService, varselService)
+
+        invoking {
+            runBlocking {
+                service.getInactiveEvents(innloggetBruker)
+            }
+        } `should throw` ConsumeEventException::class `with message containing` "Uventet feil ved sammenslåing av inaktive"
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
@@ -26,7 +26,7 @@ class VarselConsumerTest {
     private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
 
     @Test
-    fun `should call varsel endpoint on dittnav-legacy-api`() {
+    fun `Skal kalle varsel-endepunktet i dittnav-legacy-api`() {
         val client = HttpClient(MockEngine) {
             engine {
                 addHandler { request ->
@@ -49,7 +49,7 @@ class VarselConsumerTest {
     }
 
     @Test
-    fun `should get list of active Varsel`() {
+    fun `Skal mottat en liste av aktive Varsel`() {
         val varselObject = createLestVarsel("1")
         val objectMapper = ObjectMapper().apply {
             enableDittNavJsonConfig()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
@@ -1,0 +1,88 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.features.json.JsonFeature
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
+import no.nav.personbruker.dittnav.api.config.buildJsonSerializer
+import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should equal`
+import org.junit.jupiter.api.Test
+import java.net.URL
+
+class VarselConsumerTest {
+
+    private val innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
+
+    @Test
+    fun `should call varsel endpoint on dittnav-legacy-api`() {
+        val client = HttpClient(MockEngine) {
+            engine {
+                addHandler { request ->
+                    if (request.url.encodedPath.contains("/varselinnboks/siste") && request.url.host.contains("dittnav-legacy-api")) {
+                        respond("[]", headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()))
+                    } else {
+                        respondError(HttpStatusCode.BadRequest)
+                    }
+                }
+            }
+            install(JsonFeature) {
+                serializer = buildJsonSerializer()
+            }
+        }
+        val varselConsumer = VarselConsumer(client, URL("http://dittnav-legacy-api"))
+
+        runBlocking {
+            varselConsumer.getSisteVarsler(innloggetBruker) `should equal` emptyList()
+        }
+    }
+
+    @Test
+    fun `should get list of active Varsel`() {
+        val varselObject = createInactiveVarsel("1")
+        val objectMapper = ObjectMapper().apply {
+            enableDittNavJsonConfig()
+        }
+        val client = getClient {
+            respond(
+                    objectMapper.writeValueAsString(listOf(varselObject)),
+                    headers = headersOf(HttpHeaders.ContentType,
+                            ContentType.Application.Json.toString())
+            )
+        }
+        val varselConsumer = VarselConsumer(client, URL("http://dittnav-legacy-api"))
+
+        runBlocking {
+            val externalActiveEvents = varselConsumer.getSisteVarsler(innloggetBruker)
+            val event = externalActiveEvents.first()
+            externalActiveEvents.size `should be equal to` 1
+            event.varseltekst `should be equal to` varselObject.varseltekst
+            event.aktoerID `should be equal to` varselObject.aktoerID
+        }
+    }
+
+    private fun getClient(respond: MockRequestHandleScope.() -> HttpResponseData): HttpClient {
+        return HttpClient(MockEngine) {
+            engine {
+                addHandler {
+                    respond()
+                }
+            }
+            install(JsonFeature) {
+                serializer = buildJsonSerializer()
+            }
+        }
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselConsumerTest.kt
@@ -50,7 +50,7 @@ class VarselConsumerTest {
 
     @Test
     fun `should get list of active Varsel`() {
-        val varselObject = createInactiveVarsel("1")
+        val varselObject = createLestVarsel("1")
         val objectMapper = ObjectMapper().apply {
             enableDittNavJsonConfig()
         }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
@@ -10,8 +10,8 @@ fun createInactiveVarsel(eventId: String): Varsel {
         "Tekst",
         eventId,
         "3",
-        LocalDate.of(2020, 8, 8),
-        LocalDate.of(2020, 8, 9)
+        LocalDate.now().minusDays(30),
+        LocalDate.now().minusDays(20)
     )
 }
 
@@ -23,7 +23,7 @@ fun createActiveVarsel(eventId: String): Varsel {
         "Tekst",
         eventId,
         "4",
-        LocalDate.of(2020, 9, 10),
+        LocalDate.now().minusDays(10),
         null
     )
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
@@ -1,0 +1,29 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import java.time.LocalDate
+
+fun createInactiveVarsel(eventId: String): Varsel {
+    return Varsel(
+        1,
+        "2",
+        "https://en.url",
+        "Tekst",
+        eventId,
+        "3",
+        LocalDate.of(2020, 8, 8),
+        LocalDate.of(2020, 8, 9)
+    )
+}
+
+fun createActiveVarsel(eventId: String): Varsel {
+    return Varsel(
+        2,
+        "3",
+        "https://en.url",
+        "Tekst",
+        eventId,
+        "4",
+        LocalDate.of(2020, 9, 10),
+        null
+    )
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselObjectMother.kt
@@ -1,8 +1,8 @@
 package no.nav.personbruker.dittnav.api.varsel
 
-import java.time.LocalDate
+import java.time.ZonedDateTime
 
-fun createInactiveVarsel(eventId: String): Varsel {
+fun createLestVarsel(eventId: String): Varsel {
     return Varsel(
         1,
         "2",
@@ -10,12 +10,12 @@ fun createInactiveVarsel(eventId: String): Varsel {
         "Tekst",
         eventId,
         "3",
-        LocalDate.now().minusDays(30),
-        LocalDate.now().minusDays(20)
+        ZonedDateTime.now().minusDays(30),
+        ZonedDateTime.now().minusDays(20)
     )
 }
 
-fun createActiveVarsel(eventId: String): Varsel {
+fun createUlestVarsel(eventId: String): Varsel {
     return Varsel(
         2,
         "3",
@@ -23,7 +23,7 @@ fun createActiveVarsel(eventId: String): Varsel {
         "Tekst",
         eventId,
         "4",
-        LocalDate.now().minusDays(10),
+        ZonedDateTime.now().minusDays(10),
         null
     )
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
@@ -19,8 +19,8 @@ class VarselServiceTest {
 
     @Test
     fun `should return list of VarselDTO when active Events are received`() {
-        val varsel1 = createActiveVarsel("1")
-        val varsel2 = createActiveVarsel("2")
+        val varsel1 = createUlestVarsel("1")
+        val varsel2 = createUlestVarsel("2")
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
         runBlocking {
             val varselList = varselService.getActiveVarselEvents(innloggetBruker)
@@ -30,25 +30,12 @@ class VarselServiceTest {
 
     @Test
     fun `should return list of VarselDTO when inactive Events are received`() {
-        val varsel1 = createInactiveVarsel("3")
-        val varsel2 = createInactiveVarsel("4")
+        val varsel1 = createLestVarsel("3")
+        val varsel2 = createLestVarsel("4")
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
         runBlocking {
             val varselList = varselService.getInactiveVarselEvents(innloggetBruker)
             varselList.size `should be equal to` 2
-        }
-    }
-
-    @Test
-    fun `should not mask events with security level equal than current user`() {
-        val varsel = createActiveVarsel("7")
-        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
-        runBlocking {
-            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
-            val beskjedDTO = varselList.first()
-            beskjedDTO.tekst `should be equal to` varsel.varseltekst
-            beskjedDTO.link `should be equal to` varsel.url
-            beskjedDTO.sikkerhetsnivaa `should be equal to` 4
         }
     }
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
@@ -18,7 +18,7 @@ class VarselServiceTest {
     val varselService = VarselService(varselConsumer)
 
     @Test
-    fun `should return list of VarselDTO when active Events are received`() {
+    fun `Skal mottat en liste med VarselDTO i det aktive eventer hentes`() {
         val varsel1 = createUlestVarsel("1")
         val varsel2 = createUlestVarsel("2")
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
@@ -29,7 +29,7 @@ class VarselServiceTest {
     }
 
     @Test
-    fun `should return list of VarselDTO when inactive Events are received`() {
+    fun `Skal motta en liste med VarselDTO i det inaktive eventer hentes`() {
         val varsel1 = createLestVarsel("3")
         val varsel2 = createLestVarsel("4")
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
@@ -40,13 +40,13 @@ class VarselServiceTest {
     }
 
     @Test
-    fun `should throw exception if fetching active events fails`() {
+    fun `Skal kaste en exception hvis henting av aktive eventer feiler`() {
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } throws Exception("error")
         invoking { runBlocking { varselService.getActiveVarselEvents(innloggetBruker) } } `should throw` ConsumeEventException::class
     }
 
     @Test
-    fun `should throw exception if fetching inactive events fails`() {
+    fun `Skal kaste en exception hvis henting av inaktive eventer feiler`() {
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } throws Exception("error")
         invoking { runBlocking { varselService.getInactiveVarselEvents(innloggetBruker) } } `should throw` ConsumeEventException::class
     }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
@@ -40,33 +40,6 @@ class VarselServiceTest {
     }
 
     @Test
-    fun `should mask events with security level higher than current user`() {
-        val ident = "1"
-        val varsel = createActiveVarsel("5")
-        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(ident, 3)
-        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
-        runBlocking {
-            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
-            val varselDTO = varselList.first()
-            varselDTO.tekst `should be equal to` "***"
-            varselDTO.link `should be equal to` "***"
-            varselDTO.sikkerhetsnivaa `should be equal to` 4
-        }
-    }
-
-    @Test
-    fun `should not mask events with security level lower than current user`() {
-        val varsel = createActiveVarsel("6")
-        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
-        runBlocking {
-            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
-            val varselDTO = varselList.first()
-            varselDTO.tekst `should be equal to` varsel.varseltekst
-            varselDTO.link `should be equal to` varsel.url
-        }
-    }
-
-    @Test
     fun `should not mask events with security level equal than current user`() {
         val varsel = createActiveVarsel("7")
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
@@ -90,4 +63,5 @@ class VarselServiceTest {
         coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } throws Exception("error")
         invoking { runBlocking { varselService.getInactiveVarselEvents(innloggetBruker) } } `should throw` ConsumeEventException::class
     }
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselServiceTest.kt
@@ -1,0 +1,93 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.ConsumeEventException
+import no.nav.personbruker.dittnav.api.common.InnloggetBrukerObjectMother
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.invoking
+import org.junit.jupiter.api.Test
+
+class VarselServiceTest {
+
+    var innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker()
+
+    val varselConsumer = mockk<VarselConsumer>()
+    val varselService = VarselService(varselConsumer)
+
+    @Test
+    fun `should return list of VarselDTO when active Events are received`() {
+        val varsel1 = createActiveVarsel("1")
+        val varsel2 = createActiveVarsel("2")
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
+        runBlocking {
+            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
+            varselList.size `should be equal to` 2
+        }
+    }
+
+    @Test
+    fun `should return list of VarselDTO when inactive Events are received`() {
+        val varsel1 = createInactiveVarsel("3")
+        val varsel2 = createInactiveVarsel("4")
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel1, varsel2)
+        runBlocking {
+            val varselList = varselService.getInactiveVarselEvents(innloggetBruker)
+            varselList.size `should be equal to` 2
+        }
+    }
+
+    @Test
+    fun `should mask events with security level higher than current user`() {
+        val ident = "1"
+        val varsel = createActiveVarsel("5")
+        innloggetBruker = InnloggetBrukerObjectMother.createInnloggetBruker(ident, 3)
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
+        runBlocking {
+            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
+            val varselDTO = varselList.first()
+            varselDTO.tekst `should be equal to` "***"
+            varselDTO.link `should be equal to` "***"
+            varselDTO.sikkerhetsnivaa `should be equal to` 4
+        }
+    }
+
+    @Test
+    fun `should not mask events with security level lower than current user`() {
+        val varsel = createActiveVarsel("6")
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
+        runBlocking {
+            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
+            val varselDTO = varselList.first()
+            varselDTO.tekst `should be equal to` varsel.varseltekst
+            varselDTO.link `should be equal to` varsel.url
+        }
+    }
+
+    @Test
+    fun `should not mask events with security level equal than current user`() {
+        val varsel = createActiveVarsel("7")
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } returns listOf(varsel)
+        runBlocking {
+            val varselList = varselService.getActiveVarselEvents(innloggetBruker)
+            val beskjedDTO = varselList.first()
+            beskjedDTO.tekst `should be equal to` varsel.varseltekst
+            beskjedDTO.link `should be equal to` varsel.url
+            beskjedDTO.sikkerhetsnivaa `should be equal to` 4
+        }
+    }
+
+    @Test
+    fun `should throw exception if fetching active events fails`() {
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } throws Exception("error")
+        invoking { runBlocking { varselService.getActiveVarselEvents(innloggetBruker) } } `should throw` ConsumeEventException::class
+    }
+
+    @Test
+    fun `should throw exception if fetching inactive events fails`() {
+        coEvery { varselConsumer.getSisteVarsler(innloggetBruker) } throws Exception("error")
+        invoking { runBlocking { varselService.getInactiveVarselEvents(innloggetBruker) } } `should throw` ConsumeEventException::class
+    }
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
@@ -1,9 +1,28 @@
 package no.nav.personbruker.dittnav.api.varsel
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.personbruker.dittnav.api.config.enableDittNavJsonConfig
 import org.amshove.kluent.`should contain`
+import org.amshove.kluent.shouldNotBeNull
 import org.junit.jupiter.api.Test
 
 class VarselTest {
+
+    private val eksempelVarselFraLegacyApi =
+        """{"id":1,
+            |"aktoerID":"123",
+            |"url":"https://dummy.url",
+            |"varseltekst":"Tekst",
+            |"varselId":"4",
+            |"meldingsType":"a",
+            |"datoOpprettet":"2020-08-27",
+            |"datoLest":"2020-09-04"}
+            |""".trimMargin()
+
+    val objectMapper = ObjectMapper().apply {
+        enableDittNavJsonConfig()
+    }
 
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
@@ -12,6 +31,23 @@ class VarselTest {
         varselAsString `should contain` "aktoerID=***"
         varselAsString `should contain` "tekst=***"
         varselAsString `should contain` "url=***"
+    }
+
+    @Test
+    fun `skal kunne serialisere og deserialisere`() {
+        val varsel = createInactiveVarsel("1000")
+        val serialized = objectMapper.writeValueAsString(varsel)
+
+        val deserialiser = objectMapper.readValue<Varsel>(serialized)
+
+        deserialiser.shouldNotBeNull()
+    }
+
+    @Test
+    fun `skal kunne deserialisere et eksempel-varsel fra legacy-api`() {
+        val deserialized = objectMapper.readValue<Varsel>(eksempelVarselFraLegacyApi)
+
+        deserialized.shouldNotBeNull()
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
@@ -16,8 +16,8 @@ class VarselTest {
             |"varseltekst":"Tekst",
             |"varselId":"4",
             |"meldingsType":"a",
-            |"datoOpprettet":"2020-08-27",
-            |"datoLest":"2020-09-04"}
+            |"datoOpprettet":"2019-12-06T07:07:55.246+01:00[Europe/Oslo]",
+            |"datoLest":"2020-02-04T08:02:13+01:00[Europe/Oslo]"}
             |""".trimMargin()
 
     val objectMapper = ObjectMapper().apply {
@@ -26,7 +26,7 @@ class VarselTest {
 
     @Test
     fun `skal returnere maskerte data fra toString-metoden`() {
-        val varsel = createInactiveVarsel("1")
+        val varsel = createLestVarsel("1")
         val varselAsString = varsel.toString()
         varselAsString `should contain` "aktoerID=***"
         varselAsString `should contain` "tekst=***"
@@ -35,7 +35,7 @@ class VarselTest {
 
     @Test
     fun `skal kunne serialisere og deserialisere`() {
-        val varsel = createInactiveVarsel("1000")
+        val varsel = createLestVarsel("1000")
         val serialized = objectMapper.writeValueAsString(varsel)
 
         val deserialiser = objectMapper.readValue<Varsel>(serialized)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTest.kt
@@ -1,0 +1,17 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import org.amshove.kluent.`should contain`
+import org.junit.jupiter.api.Test
+
+class VarselTest {
+
+    @Test
+    fun `skal returnere maskerte data fra toString-metoden`() {
+        val varsel = createInactiveVarsel("1")
+        val varselAsString = varsel.toString()
+        varselAsString `should contain` "aktoerID=***"
+        varselAsString `should contain` "tekst=***"
+        varselAsString `should contain` "url=***"
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 class VarselTransformerTest {
 
     @Test
-    fun `should transform from Varsel to BeskjedDTO`() {
+    fun `Skal transformere fra Varsel til BeskjedDTO`() {
         val original = createLestVarsel("1")
         val beskjedDTO = toVarselDTO(original)
 

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
@@ -8,35 +8,17 @@ class VarselTransformerTest {
 
     @Test
     fun `should transform from Varsel to BeskjedDTO`() {
-        val varsel1 = createInactiveVarsel("1")
-        val varsel2 = createInactiveVarsel("2")
-        val varselDTOList = listOf(varsel1, varsel2).map { varsel ->
-            toVarselDTO(varsel)
-        }
-        val beskjedDTO = varselDTOList.first()
+        val original = createLestVarsel("1")
+        val beskjedDTO = toVarselDTO(original)
 
-        beskjedDTO.uid!! `should be equal to` varsel1.id.toString()
-        beskjedDTO.eventTidspunkt.toString() `should be equal to` varsel1.datoOpprettet.toZonedDateTime().toString()
-        beskjedDTO.eventId `should be equal to` varsel1.varselId
-        beskjedDTO.tekst `should be equal to` varsel1.varseltekst
-        beskjedDTO.link `should be equal to` varsel1.url
+        beskjedDTO.uid!! `should be equal to` original.id.toString()
+        beskjedDTO.eventTidspunkt.toString() `should be equal to` original.datoOpprettet.toString()
+        beskjedDTO.eventId `should be equal to` original.varselId
+        beskjedDTO.tekst `should be equal to` original.varseltekst
+        beskjedDTO.link `should be equal to` original.url
         beskjedDTO.produsent!! `should be equal to` "varselinnboks"
-        beskjedDTO.sistOppdatert.toString() `should be equal to` varsel1.datoLest?.toZonedDateTime().toString()
-        beskjedDTO.sikkerhetsnivaa `should be` 4
-    }
-
-    @Test
-    fun `should mask tekst, link and produsent`() {
-        val varsel = createInactiveVarsel("3")
-        val beskjedDTO = toMaskedVarselDTO(varsel)
-        beskjedDTO.uid!! `should be equal to` varsel.id.toString()
-        beskjedDTO.eventTidspunkt.toString() `should be equal to` varsel.datoOpprettet.toZonedDateTime().toString()
-        beskjedDTO.eventId `should be equal to` varsel.varselId
-        beskjedDTO.tekst `should be equal to` "***"
-        beskjedDTO.link `should be equal to` "***"
-        beskjedDTO.produsent!! `should be equal to` "***"
-        beskjedDTO.sistOppdatert.toString() `should be equal to` varsel.datoLest?.toZonedDateTime().toString()
-        beskjedDTO.sikkerhetsnivaa `should be` 4
+        beskjedDTO.sistOppdatert.toString() `should be equal to` original.datoLest!!.toString()
+        beskjedDTO.sikkerhetsnivaa `should be` 3
     }
 
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
@@ -1,0 +1,42 @@
+package no.nav.personbruker.dittnav.api.varsel
+
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be`
+import org.junit.jupiter.api.Test
+
+class VarselTransformerTest {
+
+    @Test
+    fun `should transform from Varsel to BeskjedDTO`() {
+        val varsel1 = createInactiveVarsel("1")
+        val varsel2 = createInactiveVarsel("2")
+        val varselDTOList = listOf(varsel1, varsel2).map { varsel ->
+            toVarselDTO(varsel)
+        }
+        val beskjedDTO = varselDTOList.first()
+
+        beskjedDTO.uid!! `should be equal to` varsel1.id.toString()
+        beskjedDTO.eventTidspunkt.toString() `should be equal to` varsel1.datoOpprettet.toZonedDateTime().toString()
+        beskjedDTO.eventId `should be equal to` varsel1.varselId
+        beskjedDTO.tekst `should be equal to` varsel1.varseltekst
+        beskjedDTO.link `should be equal to` varsel1.url
+        beskjedDTO.produsent!! `should be equal to` "varselinnboks"
+        beskjedDTO.sistOppdatert.toString() `should be equal to` varsel1.datoLest?.toZonedDateTime().toString()
+        beskjedDTO.sikkerhetsnivaa `should be` 4
+    }
+
+    @Test
+    fun `should mask tekst, link and produsent`() {
+        val varsel = createInactiveVarsel("3")
+        val beskjedDTO = toMaskedVarselDTO(varsel)
+        beskjedDTO.uid!! `should be equal to` varsel.id.toString()
+        beskjedDTO.eventTidspunkt.toString() `should be equal to` varsel.datoOpprettet.toZonedDateTime().toString()
+        beskjedDTO.eventId `should be equal to` varsel.varselId
+        beskjedDTO.tekst `should be equal to` "***"
+        beskjedDTO.link `should be equal to` "***"
+        beskjedDTO.produsent!! `should be equal to` "***"
+        beskjedDTO.sistOppdatert.toString() `should be equal to` varsel.datoLest?.toZonedDateTime().toString()
+        beskjedDTO.sikkerhetsnivaa `should be` 4
+    }
+
+}


### PR DESCRIPTION
Varsler fra `varselinnboks` hentes inn via `legacy-api`, og transformeres til formatet som en Brukerntotifikasjon-Beskjed. Dette gjør at det blir mulig å hente ut både Brukernotifikasjon-Beskjeder samtidig som man henter ut Varsler.

Det er nå tilgjengeliggjort to nye endepunkter i `dev`:
* `/beskjed/merged` --> Aktive Beskjeder (Brukernotifikasjon) og uleste varsler fra Varselinnboks.
* `/beskjed/merged/inaktiv` --> Inaktive Beskjeder (Brukernotifikasjon) og leste varsler fra Varselinnboks.

Det er verifisert i docker-compose at dette fungerer fint sammen med frontend-en.

Jeg tror e2e-testene feilet her fordi denne appen er avhengig av endringer fra https://github.com/navikt/dittnav-legacy-api/pull/38 som ikke er i `main` enda.