### PR TITLE
Fjernet endepunkt som hentet feil antall inaktive brukernotifikasjoner

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonConsumer.kt
@@ -11,11 +11,6 @@ class BrukernotifikasjonConsumer(
         private val pathToEndpoint: URL = URL("$eventHandlerBaseURL/count/brukernotifikasjoner")
 ) {
 
-    suspend fun countInactive(innloggetBruker: InnloggetBruker): Int {
-        val completePathToEndpoint = URL("$pathToEndpoint/inactive")
-        return client.get(completePathToEndpoint, innloggetBruker)
-    }
-
     suspend fun countActive(innloggetBruker: InnloggetBruker): Int {
         val completePathToEndpoint = URL("$pathToEndpoint/active")
         return client.get(completePathToEndpoint, innloggetBruker)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/BrukernotifikasjonService.kt
@@ -14,15 +14,6 @@ class BrukernotifikasjonService(private val brukernotifikasjonConsumer: Brukerno
         }
     }
 
-    suspend fun numberOfInactive(innloggetBruker: InnloggetBruker): Int {
-        return try {
-            brukernotifikasjonConsumer.countInactive(innloggetBruker)
-
-        } catch (exception: Exception) {
-            throw ConsumeEventException("Klarte ikke å finne ut om brukeren har inaktive brukernotifikasjoner", exception)
-        }
-    }
-
     suspend fun numberOfActive(innloggetBruker: InnloggetBruker): Int {
         return try {
             brukernotifikasjonConsumer.countActive(innloggetBruker)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -23,16 +23,6 @@ fun Route.brukernotifikasjoner(service: BrukernotifikasjonService) {
         }
     }
 
-    get("/brukernotifikasjon/count/inactive") {
-        try {
-            val numberOfInactiveEvents = service.numberOfInactive(innloggetBruker)
-            call.respond(HttpStatusCode.OK, numberOfInactiveEvents)
-
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
-        }
-    }
-
     get("/brukernotifikasjon/count/active") {
         try {
             val numberOfActiveEvents = service.numberOfActive(innloggetBruker)


### PR DESCRIPTION
Fjernet endepunkt som hentet feil antall inaktive brukernotifikasjoner. Det ikke tok ikke hensyn til inaktive brukernotifikasjoner som ble satt med synligFremTil. Logikken som avgjør om inngangen til historikksiden skal vises ligger i frontend.

PB-512: Rydde bort quickfix-er i dittnav.