### PR TITLE
PB-521: Logging når et token har to minutter igjen

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -32,12 +32,6 @@ fun Route.beskjed(
     get("/beskjed/inaktiv") {
         try {
             val beskjedEvents = beskjedVarselSwitcher.getInactiveEvents(innloggetBruker)
-            val headers: ResponseHeaders = call.response.headers
-
-            if (headers.contains("x-token-expires-soon")) {
-                log.debug("X-token-expires-soon er satt til true")
-            }
-
             call.respond(HttpStatusCode.OK, beskjedEvents)
 
         } catch (exception: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -7,6 +7,7 @@ import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.Environment
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
+import no.nav.personbruker.dittnav.api.logging.logTokenExpiry
 import org.slf4j.LoggerFactory
 
 fun Route.beskjed(
@@ -20,6 +21,7 @@ fun Route.beskjed(
     get("/beskjed") {
         try {
             val beskjedEvents = beskjedVarselSwitcher.getActiveEvents(innloggetBruker)
+            logTokenExpiry(log, call)
             call.respond(HttpStatusCode.OK, beskjedEvents)
 
         } catch (exception: Exception) {
@@ -30,6 +32,12 @@ fun Route.beskjed(
     get("/beskjed/inaktiv") {
         try {
             val beskjedEvents = beskjedVarselSwitcher.getInactiveEvents(innloggetBruker)
+            val headers: ResponseHeaders = call.response.headers
+
+            if (headers.contains("x-token-expires-soon")) {
+                log.debug("X-token-expires-soon er satt til true")
+            }
+
             call.respond(HttpStatusCode.OK, beskjedEvents)
 
         } catch (exception: Exception) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -4,13 +4,11 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.client.statement.readBytes
 import io.ktor.http.HttpStatusCode
-import io.ktor.response.ResponseHeaders
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
-import no.nav.personbruker.dittnav.api.logging.logTokenExpiry
 import org.slf4j.LoggerFactory
 import java.net.SocketTimeoutException
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -4,11 +4,13 @@ import io.ktor.application.ApplicationCall
 import io.ktor.application.call
 import io.ktor.client.statement.readBytes
 import io.ktor.http.HttpStatusCode
+import io.ktor.response.ResponseHeaders
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.util.pipeline.PipelineContext
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
+import no.nav.personbruker.dittnav.api.logging.logTokenExpiry
 import org.slf4j.LoggerFactory
 import java.net.SocketTimeoutException
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/logTokenExpiry.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/logTokenExpiry.kt
@@ -8,7 +8,7 @@ fun logTokenExpiry(log: Logger, call: ApplicationCall) {
     val headers: ResponseHeaders = call.response.headers
 
     if (headers.contains("x-token-expires-soon")) {
-        log.warn("Et kall fra dittnav er gjort med et token som har to minutter igjen.")
+        log.info("Et kall fra dittnav er gjort med et token som har to minutter igjen.")
     }
 }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/logTokenExpiry.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/logTokenExpiry.kt
@@ -1,0 +1,14 @@
+package no.nav.personbruker.dittnav.api.logging
+
+import io.ktor.application.ApplicationCall
+import io.ktor.response.ResponseHeaders
+import org.slf4j.Logger
+
+fun logTokenExpiry(log: Logger, call: ApplicationCall) {
+    val headers: ResponseHeaders = call.response.headers
+
+    if (headers.contains("x-token-expires-soon")) {
+        log.warn("Et kall fra dittnav er gjort med et token som har to minutter igjen.")
+    }
+}
+


### PR DESCRIPTION
Har lagt til en `log.warning()` når det gjøres et kall fra dittnav med et token som har to minutter igjen. Logikken fra `token-support` gjenbrukes og i første omgang logges det bare en gang i /beskjed route-en.

PB-521:  Logging når et token har to minutter igjen.