### PR TITLE
Sørger for at alle data kommer med fra Varselinnboks

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/varsel/varselTransformer.kt
@@ -8,7 +8,7 @@ import java.time.ZonedDateTime
 fun toVarselDTO(externalVarsel: Varsel): BeskjedDTO =
     externalVarsel.let { varsel ->
         BeskjedDTO(
-            uid = "${varsel.id}",
+            uid = "${varsel.meldingsType}-${varsel.varselId}",
             eventTidspunkt = varsel.datoOpprettet,
             eventId = varsel.varselId,
             tekst = cropTextIfOverMaxLengthOfBeskjed(varsel.varseltekst),

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/varsel/VarselTransformerTest.kt
@@ -11,7 +11,7 @@ class VarselTransformerTest {
         val original = createLestVarsel("1")
         val beskjedDTO = toVarselDTO(original)
 
-        beskjedDTO.uid!! `should be equal to` original.id.toString()
+        beskjedDTO.uid!! `should be equal to` "${original.meldingsType}-${original.id}"
         beskjedDTO.eventTidspunkt.toString() `should be equal to` original.datoOpprettet.toString()
         beskjedDTO.eventId `should be equal to` original.varselId
         beskjedDTO.tekst `should be equal to` original.varseltekst


### PR DESCRIPTION
Sørger for at alle data fra Varselinnboks-varsler kommer med i konverteringen til Beskjed.

Siden det ikke finnes et eget felt for `meldingsType` i Beskjed, så er det lagt inn som en del av Beskjedens UID. Dermed vil det være mulig å parse dette ut fra en Beskjed igjen.