### PR TITLE
Flyttet debugloggingen av token som snart er i ferd med å løpe ut

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedConsumer.kt
@@ -1,9 +1,8 @@
 package no.nav.personbruker.dittnav.api.beskjed
 
-import io.ktor.client.HttpClient
+import io.ktor.client.*
 import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.get
-import org.slf4j.LoggerFactory
 import java.net.URL
 
 class BeskjedConsumer(
@@ -12,12 +11,9 @@ class BeskjedConsumer(
         private val pathToEndpoint: URL = URL("$eventHandlerBaseURL/fetch/beskjed")
 ) {
 
-    private val log = LoggerFactory.getLogger(BeskjedConsumer::class.java)
-
     suspend fun getExternalActiveEvents(innloggetBruker: InnloggetBruker): List<Beskjed> {
         val completePathToEndpoint = URL("$pathToEndpoint/aktive")
         val externalActiveEvents = getExternalEvents(innloggetBruker, completePathToEndpoint)
-        logWhenTokenIsAboutToExpire(innloggetBruker)
         return externalActiveEvents
     }
 
@@ -25,14 +21,6 @@ class BeskjedConsumer(
         val completePathToEndpoint = URL("$pathToEndpoint/inaktive")
         val externalInactiveEvents = getExternalEvents(innloggetBruker, completePathToEndpoint)
         return externalInactiveEvents
-    }
-
-    private fun logWhenTokenIsAboutToExpire(innloggetBruker: InnloggetBruker) {
-        val expiryThresholdInMinutes = 2L
-
-        if (innloggetBruker.isTokenAboutToExpire(expiryThresholdInMinutes)) {
-            log.info("Det er mindre enn $expiryThresholdInMinutes minutter før token-et går ut for: $innloggetBruker")
-        }
     }
 
     private suspend fun getExternalEvents(innloggetBruker: InnloggetBruker, completePathToEndpoint: URL): List<Beskjed> {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -8,6 +8,7 @@ import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.util.pipeline.PipelineContext
+import no.nav.personbruker.dittnav.api.common.InnloggetBruker
 import no.nav.personbruker.dittnav.api.config.innloggetBruker
 import org.slf4j.LoggerFactory
 import java.net.SocketTimeoutException
@@ -25,6 +26,7 @@ fun Route.legacyApi(legacyConsumer: LegacyConsumer) {
     val oppfolgingPath = "/oppfolging"
 
     get(ubehandledeMeldingerPath) {
+        logWhenTokenIsAboutToExpire(innloggetBruker)
         hentRaattFraLegacyApiOgReturnerResponsen(legacyConsumer, ubehandledeMeldingerPath)
     }
 
@@ -66,4 +68,12 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.hentRaattFraLegacyApi
         call.respond(HttpStatusCode.InternalServerError)
     }
 
+}
+
+fun logWhenTokenIsAboutToExpire(innloggetBruker: InnloggetBruker) {
+    val expiryThresholdInMinutes = 2L
+
+    if (innloggetBruker.isTokenAboutToExpire(expiryThresholdInMinutes)) {
+        log.info("Det er mindre enn $expiryThresholdInMinutes minutter før token-et går ut for: $innloggetBruker")
+    }
 }


### PR DESCRIPTION
Ønsker kun å sjekke dette for kall som går til `legacy-api`, fordi det er disse kallene som er tregest. Det går alltid fem kall til `legacy-api`, men velger kun å sjekke for et av de. Valgte da det antatt tregeste kallet, fordi det er der det er mest sannsynlig at det kan skje en timeout.