### PR TITLE
…

### DIFF
--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     team: personbruker
 spec:
+  envFrom:
+    - configmap: loginservice-idporten
   image: {{version}}
   port: 8080
   liveness:

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -15,8 +15,8 @@ no.nav.security.jwt {
     issuers = [
         {
             issuer_name = ${?OIDC_ISSUER}
-            discoveryurl = ${?OIDC_DISCOVERY_URL}
-            accepted_audience = ${?OIDC_ACCEPTED_AUDIENCE}
+            discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
+            accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
             cookie_name = selvbetjening-idtoken
         }
     ]

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -14,7 +14,7 @@ no.nav.security.jwt {
     expirythreshold = 2 #threshold in minutes until token expires
     issuers = [
         {
-            issuer_name = ${?OIDC_ISSUER}
+            issuer_name = "selvbetjening"
             discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
             accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
             cookie_name = selvbetjening-idtoken


### PR DESCRIPTION
Microsoft har besluttet at login.microsoftonline.com for Azure AD B2C slutter å fungere fra og med den 4. desember 2020. Endringen medfører at URL til discovery/well-known og jwks endepunktene endrer seg i tillegg til issuer i tokenet.

ConfigMap for apper på NAIS
For å lette arbeidet med å bytte har nais-teamet laget et ConfigMap som inneholder gjeldende discovery URL i alle clustrene.

For å få denne inn som en miljøvariabel i poden må vi legge følgende inn i nais.yaml:

```
spec:
  envFrom:
   - configmap: loginservice-idporten
```

Dette vil tilgjengeliggjøre miljøvariablene:

LOGINSERVICE_IDPORTEN_DISCOVERY_URL
LOGINSERVICE_IDPORTEN_AUDIENCE