### PR TITLE
Ny versjon av dittnav-dependencies, der bare Ktor er oppdatert.

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.03.05-07.47-f7531b5f7606"
+val dittNavDependenciesVersion = "2021.03.05-12.55-7ea26b8f8982"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")


### PR DESCRIPTION
Starter litt mer forsiktig, med bare å oppdatere Ktor