### PR TITLE
Ekstra sjekk som sørger for at det ikke blir sendt kall med nylig utgåtte token mot legacy-systemer

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -5,6 +5,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.beskjed(
@@ -14,28 +15,32 @@ fun Route.beskjed(
     val log = LoggerFactory.getLogger(BeskjedService::class.java)
 
     get("/beskjed") {
-        try {
-            val result = beskjedVarselSwitcher.getActiveEvents(authenticatedUser)
-            if(result.hasErrors()) {
-                log.warn("En eller flere kilder feilet: ${result.errors()}")
-            }
-            call.respond(result.determineHttpCode(), result.results())
+        executeOnUnexpiredTokensOnly {
+            try {
+                val result = beskjedVarselSwitcher.getActiveEvents(authenticatedUser)
+                if(result.hasErrors()) {
+                    log.warn("En eller flere kilder feilet: ${result.errors()}")
+                }
+                call.respond(result.determineHttpCode(), result.results())
 
-        } catch (exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 
     get("/beskjed/inaktiv") {
-        try {
-            val result = beskjedVarselSwitcher.getInactiveEvents(authenticatedUser)
-            if(result.hasErrors()) {
-                log.warn("En eller flere kilder feilet: ${result.errors()}")
-            }
-            call.respond(result.determineHttpCode(), result.results())
+        executeOnUnexpiredTokensOnly {
+            try {
+                val result = beskjedVarselSwitcher.getInactiveEvents(authenticatedUser)
+                if(result.hasErrors()) {
+                    log.warn("En eller flere kilder feilet: ${result.errors()}")
+                }
+                call.respond(result.determineHttpCode(), result.results())
 
-        } catch (exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -7,6 +7,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.brukernotifikasjoner(service: BrukernotifikasjonService) {
@@ -14,32 +15,38 @@ fun Route.brukernotifikasjoner(service: BrukernotifikasjonService) {
     val log = LoggerFactory.getLogger(BrukernotifikasjonService::class.java)
 
     get("/brukernotifikasjon/count") {
-        try {
-            val totalNumberOfEvents = service.totalNumberOfEvents(authenticatedUser)
-            call.respond(HttpStatusCode.OK, totalNumberOfEvents)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val totalNumberOfEvents = service.totalNumberOfEvents(authenticatedUser)
+                call.respond(HttpStatusCode.OK, totalNumberOfEvents)
 
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch(exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 
     get("/brukernotifikasjon/count/inactive") {
-        try {
-            val numberOfInactiveEvents = service.numberOfInactive(authenticatedUser)
-            call.respond(HttpStatusCode.OK, numberOfInactiveEvents)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val numberOfInactiveEvents = service.numberOfInactive(authenticatedUser)
+                call.respond(HttpStatusCode.OK, numberOfInactiveEvents)
 
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch(exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 
     get("/brukernotifikasjon/count/active") {
-        try {
-            val numberOfActiveEvents = service.numberOfActive(authenticatedUser)
-            call.respond(HttpStatusCode.OK, numberOfActiveEvents)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val numberOfActiveEvents = service.numberOfActive(authenticatedUser)
+                call.respond(HttpStatusCode.OK, numberOfActiveEvents)
 
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+            } catch(exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
@@ -7,13 +7,16 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 
 fun Route.doneApi(doneProducer: DoneProducer) {
 
     post("/produce/done") {
-        respondForParameterType<DoneDTO> { doneDto ->
-            val response = doneProducer.postDoneEvents(doneDto, authenticatedUser)
-            response
+        executeOnUnexpiredTokensOnly {
+            respondForParameterType<DoneDTO> { doneDto ->
+                val response = doneProducer.postDoneEvents(doneDto, authenticatedUser)
+                response
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
@@ -7,15 +7,10 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.logWhenTokenIsAboutToExpire
-import org.slf4j.LoggerFactory
 
 fun Route.doneApi(doneProducer: DoneProducer) {
 
-    val log = LoggerFactory.getLogger(DoneProducer::class.java)
-
     post("/produce/done") {
-        log.logWhenTokenIsAboutToExpire(authenticatedUser)
         respondForParameterType<DoneDTO> { doneDto ->
             val response = doneProducer.postDoneEvents(doneDto, authenticatedUser)
             response

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/health/authenticationCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/health/authenticationCheck.kt
@@ -5,12 +5,15 @@ import io.ktor.http.ContentType
 import io.ktor.response.respondText
 import io.ktor.routing.Route
 import io.ktor.routing.get
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 
 fun Route.authenticationCheck() {
 
     val pingJsonResponse = """{"ping": "pong"}"""
 
     get("/authPing") {
-        call.respondText(pingJsonResponse, ContentType.Application.Json)
+        executeOnUnexpiredTokensOnly {
+            call.respondText(pingJsonResponse, ContentType.Application.Json)
+        }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
@@ -7,6 +7,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.innboks(innboksService: InnboksService) {
@@ -14,20 +15,24 @@ fun Route.innboks(innboksService: InnboksService) {
     val log = LoggerFactory.getLogger(InnboksService::class.java)
 
     get("/innboks") {
-        try {
-            val innboksEvents = innboksService.getActiveInnboksEvents(authenticatedUser)
-            call.respond(HttpStatusCode.OK, innboksEvents)
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val innboksEvents = innboksService.getActiveInnboksEvents(authenticatedUser)
+                call.respond(HttpStatusCode.OK, innboksEvents)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 
     get("/innboks/inaktiv") {
-        try {
-            val innboksEvents = innboksService.getInactiveInnboksEvents(authenticatedUser)
-            call.respond(HttpStatusCode.OK, innboksEvents)
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val innboksEvents = innboksService.getInactiveInnboksEvents(authenticatedUser)
+                call.respond(HttpStatusCode.OK, innboksEvents)
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -7,8 +7,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
-import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.net.SocketTimeoutException
 
@@ -25,7 +23,6 @@ fun Route.legacyApi(legacyConsumer: LegacyConsumer) {
     val oppfolgingPath = "/oppfolging"
 
     get(ubehandledeMeldingerPath) {
-        log.logWhenTokenIsAboutToExpire(authenticatedUser)
         hentRaattFraLegacyApiOgReturnerResponsen(legacyConsumer, ubehandledeMeldingerPath)
     }
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -68,7 +68,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.hentRaattFraLegacyApi
     }
 }
 
-private suspend fun PipelineContext<Unit, ApplicationCall>.executeOnUnexpiredTokensOnly(block: suspend () -> Unit) {
+suspend fun PipelineContext<Unit, ApplicationCall>.executeOnUnexpiredTokensOnly(block: suspend () -> Unit) {
     if (authenticatedUser.isTokenExpired()) {
         val delta = authenticatedUser.tokenExpirationTime.epochSecond - Instant.now().epochSecond
         log.info("Mottok kall fra en bruker med et utløpt token. Tid siden tokenet løp ut: $delta sekunder, $authenticatedUser")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
@@ -1,13 +1,11 @@
 package no.nav.personbruker.dittnav.api.oppgave
 
-import io.ktor.application.call
-import io.ktor.http.HttpStatusCode
-import io.ktor.response.respond
-import io.ktor.routing.Route
-import io.ktor.routing.get
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.logWhenTokenIsAboutToExpire
 import org.slf4j.LoggerFactory
 
 fun Route.oppgave(oppgaveService: OppgaveService) {
@@ -15,7 +13,6 @@ fun Route.oppgave(oppgaveService: OppgaveService) {
     val log = LoggerFactory.getLogger(OppgaveService::class.java)
 
     get("/oppgave") {
-        log.logWhenTokenIsAboutToExpire(authenticatedUser)
         try {
             val oppgaveEvents = oppgaveService.getActiveOppgaveEvents(authenticatedUser)
             call.respond(HttpStatusCode.OK, oppgaveEvents)
@@ -25,7 +22,6 @@ fun Route.oppgave(oppgaveService: OppgaveService) {
     }
 
     get("/oppgave/inaktiv") {
-        log.logWhenTokenIsAboutToExpire(authenticatedUser)
         try {
             val oppgaveEvents = oppgaveService.getInactiveOppgaveEvents(authenticatedUser)
             call.respond(HttpStatusCode.OK, oppgaveEvents)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
@@ -6,6 +6,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.oppgave(oppgaveService: OppgaveService) {
@@ -13,20 +14,24 @@ fun Route.oppgave(oppgaveService: OppgaveService) {
     val log = LoggerFactory.getLogger(OppgaveService::class.java)
 
     get("/oppgave") {
-        try {
-            val oppgaveEvents = oppgaveService.getActiveOppgaveEvents(authenticatedUser)
-            call.respond(HttpStatusCode.OK, oppgaveEvents)
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val oppgaveEvents = oppgaveService.getActiveOppgaveEvents(authenticatedUser)
+                call.respond(HttpStatusCode.OK, oppgaveEvents)
+            } catch(exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 
     get("/oppgave/inaktiv") {
-        try {
-            val oppgaveEvents = oppgaveService.getInactiveOppgaveEvents(authenticatedUser)
-            call.respond(HttpStatusCode.OK, oppgaveEvents)
-        } catch(exception: Exception) {
-            respondWithError(call, log, exception)
+        executeOnUnexpiredTokensOnly {
+            try {
+                val oppgaveEvents = oppgaveService.getInactiveOppgaveEvents(authenticatedUser)
+                call.respond(HttpStatusCode.OK, oppgaveEvents)
+            } catch(exception: Exception) {
+                respondWithError(call, log, exception)
+            }
         }
     }
 }


### PR DESCRIPTION
Dette gjøres fordi disse systemene ikke nødvendigvis bruker token-support for å validere tokens. Lar det inntil videre være for event-handler, siden den bruker token-support og det ikke genererer noe støy.

Ønsket egentlig å bruke en interceptor for å sørge for at dette skjer for alle kall, men det var mye mer styrete å sette opp. Fordi det ikke var helt rett fram å få en interceptor til å avslutte videre behandling av kallet, etter at token-support har validert tokenet. Kan se videre på det.

Denne PR løser det umiddelbare problemet mot systemene bakover, og gir oss tid til å lage en ordentlig interceptor.