### PR TITLE
Flyttet felleslogikken som avviser utløpte tokens

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/beskjedApi.kt
@@ -5,7 +5,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.beskjed(

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/brukernotifikasjon/brukernotifikasjonApi.kt
@@ -7,7 +7,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.brukernotifikasjoner(service: BrukernotifikasjonService) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/done/doneApi.kt
@@ -7,7 +7,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.pipeline.*
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 
 fun Route.doneApi(doneProducer: DoneProducer) {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/health/authenticationCheck.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/health/authenticationCheck.kt
@@ -5,7 +5,7 @@ import io.ktor.http.ContentType
 import io.ktor.response.respondText
 import io.ktor.routing.Route
 import io.ktor.routing.get
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 
 fun Route.authenticationCheck() {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/innboks/innboksApi.kt
@@ -7,7 +7,7 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.innboks(innboksService: InnboksService) {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/legacyApi.kt
@@ -71,7 +71,9 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.hentRaattFraLegacyApi
 suspend fun PipelineContext<Unit, ApplicationCall>.executeOnUnexpiredTokensOnly(block: suspend () -> Unit) {
     if (authenticatedUser.isTokenExpired()) {
         val delta = authenticatedUser.tokenExpirationTime.epochSecond - Instant.now().epochSecond
-        log.info("Mottok kall fra en bruker med et utløpt token. Tid siden tokenet løp ut: $delta sekunder, $authenticatedUser")
+        val msg = "Mottok kall fra en bruker med et utløpt token, avviser request-en med en 401-respons. " +
+                "Tid siden tokenet løp ut: $delta sekunder, $authenticatedUser"
+        no.nav.personbruker.dittnav.api.config.log.info(msg)
         call.respond(HttpStatusCode.Unauthorized)
 
     } else {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/oppgaveApi.kt
@@ -6,7 +6,7 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.personbruker.dittnav.api.common.respondWithError
 import no.nav.personbruker.dittnav.api.config.authenticatedUser
-import no.nav.personbruker.dittnav.api.legacy.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
 import org.slf4j.LoggerFactory
 
 fun Route.oppgave(oppgaveService: OppgaveService) {


### PR DESCRIPTION
Slik at det er mer tydelig at dette gjelder alle kall, ikke bare de mot legacy-api.