### PR TITLE
Tar høyde for ulogiske data fra Saksoversikt

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstema.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstema.kt
@@ -10,5 +10,5 @@ data class LegacySakstema(
         val temanavn: String,
         val temakode: String,
         val antallStatusUnderBehandling: Int,
-        val sisteOppdatering: ZonedDateTime
+        val sisteOppdatering: ZonedDateTime?
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/legacyTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/legacyTransformer.kt
@@ -2,19 +2,30 @@ package no.nav.personbruker.dittnav.api.legacy.saksoversikt
 
 import no.nav.personbruker.dittnav.api.saker.SakstemaDTO
 import no.nav.personbruker.dittnav.api.saker.SisteSakstemaerDTO
+import org.slf4j.LoggerFactory
 import java.time.ZonedDateTime
 
+private val log = LoggerFactory.getLogger("LegacyTransformerKt")
+
 fun List<LegacySakstema>.toInternal(): List<SakstemaDTO> {
-    return filterNotNull(). map { external ->
-        external.toInternal()
-    }.toList()
+    val internals = mutableListOf<SakstemaDTO>()
+    filterNotNull().forEachIndexed { index, external ->
+        try {
+            val internal = external.toInternal()
+            internals.add(internal)
+
+        } catch (e : Exception) {
+            log.warn("Klarte ikke å transforemere sakstemaet med index $index: $external.")
+        }
+    }
+    return internals
 }
 
 fun LegacySakstema.toInternal(): SakstemaDTO {
     return SakstemaDTO(
         navn = temanavn,
         kode = temakode,
-        sistEndret = sisteOppdatering,
+        sistEndret = sisteOppdatering ?: throw IllegalArgumentException("Dato for siste oppdatering mangler"),
         detaljvisningUrl = innsynsUrlResolverSingleton.urlFor(temakode)
     )
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstemaObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstemaObjectMother.kt
@@ -32,4 +32,11 @@ object LegacySakstemaObjectMother {
         ZonedDateTime.now().minusMonths(5)
     )
 
+    fun giveMeSakstemaUtenSisteEndret() = LegacySakstema(
+        "Økonomisk sosialhjelp",
+        "KOM",
+        5,
+        null
+    )
+
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstemaTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacySakstemaTest.kt
@@ -1,0 +1,37 @@
+package no.nav.personbruker.dittnav.api.legacy.saksoversikt
+
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import no.nav.personbruker.dittnav.api.config.json
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+internal class LegacySakstemaTest {
+
+    val responsHvorSisteOppdateringErNull = """
+        {
+          "temanavn": "Dagpenger",
+          "temakode": "DAG",
+          "antallStatusUnderBehandling": 1,
+          "sisteOppdatering": null
+        }
+    """.trimIndent()
+
+    @Test
+    fun `Skal klare aa serialisere og deserialisere gyldige responser`() {
+        val original = LegacySakstemaObjectMother.giveMeSakstemaDagpenger()
+
+        val serialized = json().encodeToString(original)
+        val deserialized = json().decodeFromString<LegacySakstema>(serialized)
+
+        deserialized.shouldNotBeNull()
+    }
+
+    @Test
+    fun `Skal taale respons med ulogiske data`() {
+        val deserialized = json().decodeFromString<LegacySakstema>(responsHvorSisteOppdateringErNull)
+
+        deserialized.shouldNotBeNull()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacyTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/legacy/saksoversikt/LegacyTransformerTest.kt
@@ -1,9 +1,6 @@
 package no.nav.personbruker.dittnav.api.legacy.saksoversikt
 
-import org.amshove.kluent.`should be equal to`
-import org.amshove.kluent.`should contain`
-import org.amshove.kluent.shouldBeNull
-import org.amshove.kluent.shouldNotBeNull
+import org.amshove.kluent.*
 import org.junit.jupiter.api.Test
 
 internal class LegacyTransformerTest {
@@ -71,6 +68,33 @@ internal class LegacyTransformerTest {
         internal.navn `should be equal to` external.temanavn
         internal.sistEndret `should be equal to` external.sisteOppdatering
         internal.detaljvisningUrl.toString() `should contain` "dagpenger"
+    }
+
+    @Test
+    fun `Skal kaste en feil hvis et enklet sakstema mangler datoen for siste oppdatering`() {
+        val external = LegacySakstemaObjectMother.giveMeSakstemaUtenSisteEndret()
+
+        val result = runCatching {
+            external.toInternal()
+        }
+
+        result.shouldNotBeNull()
+        result.isFailure `should be equal to` true
+        val exception = result.exceptionOrNull()
+        exception `should be instance of` IllegalArgumentException::class
+    }
+
+    @Test
+    fun `Sakstemaer som mangler datoen for siste oppdatering skal filtereres og ikke tas med videre`() {
+        val externals = listOf(
+            LegacySakstemaObjectMother.giveMeSakstemaDagpenger(),
+            LegacySakstemaObjectMother.giveMeSakstemaUtenSisteEndret()
+        )
+
+        val internals = externals.toInternal()
+
+        internals.shouldNotBeNull()
+        internals.size `should be equal to` 1
     }
 
 }


### PR DESCRIPTION
I noen tilfeller ser det ut som at Saksoversikt returnerer sakstemaer uten datoen for siste oppdatering. Ved slike tilfeller logges det, og sakstemaet tas ikke med videre. Siden det uansett ikke kan brukes for å gjøre logikk rundt datoen for siste oppdatering.