### PR TITLE
Tar i brukt ny versjon av Logback som har fikset feilen som gir stackoverflow (må trigges på nytt)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
     // Use jcenter for resolving your dependencies.
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
+    mavenCentral()
     maven("https://packages.confluent.io/maven")
     maven("https://jitpack.io")
     mavenLocal()
@@ -43,7 +44,7 @@ dependencies {
     implementation(Micrometer.registryPrometheus)
     implementation(Ktor.serialization)
     implementation(Ktor.serverNetty)
-    implementation(Logback.classic)
+    implementation("ch.qos.logback:logback-classic:1.3.0-alpha10")
     implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
     implementation(Prometheus.common)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(Micrometer.registryPrometheus)
     implementation(Ktor.serialization)
     implementation(Ktor.serverNetty)
-    implementation("ch.qos.logback:logback-classic:1.3.0-alpha10")
+    implementation(Logback.classic)
     implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
     implementation(Prometheus.common)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.11.09-12.25-fbd35517b350"
+val dittNavDependenciesVersion = "upgradeToKtor165-SNAPSHOT"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -31,7 +31,6 @@ import java.time.Instant
 
 val log = LoggerFactory.getLogger(ApplicationContext::class.java)
 
-@KtorExperimentalAPI
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
 
     DefaultExports.initialize()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedLoggingEvent.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedLoggingEvent.kt
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.IThrowableProxy
 import ch.qos.logback.classic.spi.LoggerContextVO
 import no.nav.personbruker.dittnav.api.logging.MaskedThrowableProxy.Companion.mask
 import org.slf4j.Marker
+import org.slf4j.event.KeyValuePair
 
 class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggingEvent) : ILoggingEvent {
     override fun getThreadName(): String? {
@@ -52,6 +53,10 @@ class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggin
         return iLoggingEvent.marker
     }
 
+    override fun getMarkerList(): MutableList<Marker>? {
+        return iLoggingEvent.markerList
+    }
+
     override fun getMDCPropertyMap(): Map<String?, String?>? {
         return iLoggingEvent.mdcPropertyMap.mapValues { mask(it.value) }
     }
@@ -62,6 +67,14 @@ class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggin
 
     override fun getTimeStamp(): Long {
         return iLoggingEvent.timeStamp
+    }
+
+    override fun getSequenceNumber(): Long {
+        return iLoggingEvent.sequenceNumber
+    }
+
+    override fun getKeyValuePairs(): MutableList<KeyValuePair>? {
+        return iLoggingEvent.keyValuePairs
     }
 
     override fun prepareForDeferredProcessing() {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedThrowableProxy.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedThrowableProxy.kt
@@ -34,6 +34,10 @@ class MaskedThrowableProxy private constructor(private val throwableProxy: IThro
         return maskedSuppressed
     }
 
+    override fun isCyclic(): Boolean {
+        return throwableProxy.isCyclic
+    }
+
     companion object {
         @JvmStatic
         fun mask(throwableProxy: IThrowableProxy?): IThrowableProxy? {


### PR DESCRIPTION
Tar den nye versjonen først i brukt uten å legge den som en del av dittnav-dependencies, for å ha oversikt over om det er mer som må oppgraderes samtidig.

Oppretter denne PR-en primært for å kjøre e2e-testene, og ønsker å trigge den på nytt fordi e2e-testene i den forrige PR-en satt seg fast.