### PR TITLE
Oppgradert til Ktor versjon som er kompatibel med vår konfig i dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
     // Use jcenter for resolving your dependencies.
     // You can declare any Maven/Ivy/file repository here.
     jcenter()
+    mavenCentral()
     maven("https://packages.confluent.io/maven")
     maven("https://jitpack.io")
     mavenLocal()
@@ -43,7 +44,7 @@ dependencies {
     implementation(Micrometer.registryPrometheus)
     implementation(Ktor.serialization)
     implementation(Ktor.serverNetty)
-    implementation(Logback.classic)
+    implementation("ch.qos.logback:logback-classic:1.3.0-alpha10")
     implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
     implementation(Prometheus.common)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation(Micrometer.registryPrometheus)
     implementation(Ktor.serialization)
     implementation(Ktor.serverNetty)
-    implementation("ch.qos.logback:logback-classic:1.3.0-alpha10")
+    implementation(Logback.classic)
     implementation(Logstash.logbackEncoder)
     implementation(NAV.tokenValidatorKtor)
     implementation(Prometheus.common)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "2021.11.09-12.25-fbd35517b350"
+val dittNavDependenciesVersion = "upgradeToKtor165-SNAPSHOT"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,7 +7,7 @@ repositories {
     maven("https://jitpack.io")
 }
 
-val dittNavDependenciesVersion = "upgradeToKtor165-SNAPSHOT"
+val dittNavDependenciesVersion = "upgradeToKtor163-SNAPSHOT"
 
 dependencies {
     implementation("com.github.navikt:dittnav-dependencies:$dittNavDependenciesVersion")

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -31,7 +31,6 @@ import java.time.Instant
 
 val log = LoggerFactory.getLogger(ApplicationContext::class.java)
 
-@KtorExperimentalAPI
 fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()) {
 
     DefaultExports.initialize()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedLoggingEvent.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedLoggingEvent.kt
@@ -6,6 +6,7 @@ import ch.qos.logback.classic.spi.IThrowableProxy
 import ch.qos.logback.classic.spi.LoggerContextVO
 import no.nav.personbruker.dittnav.api.logging.MaskedThrowableProxy.Companion.mask
 import org.slf4j.Marker
+import org.slf4j.event.KeyValuePair
 
 class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggingEvent) : ILoggingEvent {
     override fun getThreadName(): String? {
@@ -52,6 +53,10 @@ class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggin
         return iLoggingEvent.marker
     }
 
+    override fun getMarkerList(): MutableList<Marker>? {
+        return iLoggingEvent.markerList
+    }
+
     override fun getMDCPropertyMap(): Map<String?, String?>? {
         return iLoggingEvent.mdcPropertyMap.mapValues { mask(it.value) }
     }
@@ -62,6 +67,14 @@ class MaskedLoggingEvent internal constructor(private val iLoggingEvent: ILoggin
 
     override fun getTimeStamp(): Long {
         return iLoggingEvent.timeStamp
+    }
+
+    override fun getSequenceNumber(): Long {
+        return iLoggingEvent.sequenceNumber
+    }
+
+    override fun getKeyValuePairs(): MutableList<KeyValuePair>? {
+        return iLoggingEvent.keyValuePairs
     }
 
     override fun prepareForDeferredProcessing() {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedThrowableProxy.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/logging/MaskedThrowableProxy.kt
@@ -34,6 +34,10 @@ class MaskedThrowableProxy private constructor(private val throwableProxy: IThro
         return maskedSuppressed
     }
 
+    override fun isCyclic(): Boolean {
+        return throwableProxy.isCyclic
+    }
+
     companion object {
         @JvmStatic
         fun mask(throwableProxy: IThrowableProxy?): IThrowableProxy? {


### PR DESCRIPTION
Den egentlige oppgaven her er å ta i bruk en ny versjon av Logback som hinderer stack-over-flow-feilen i loggene. Bruker foreløpig en snapshot-versjon av `dittnav-dependencis` som inneholder alle biblioteker som måtte oppdateres for å unngå nye warnings ved bygging av appen.

Det er nå verifisert at e2e-testene kjører lokalt.

Oppretter denne PR-en primært for å få kjøre e2e-testene via GHA.