### PR TITLE
Øker timeout-en mot Mine Saker

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -27,6 +27,19 @@ suspend inline fun <reified T> HttpClient.get(url: URL, accessToken: AccessToken
     }
 }
 
+suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
+    request<T> {
+        url(url)
+        method = HttpMethod.Get
+        header(HttpHeaders.Authorization, "Bearer ${accessToken.value}")
+        timeout {
+            socketTimeoutMillis = 30000
+            connectTimeoutMillis = 10000
+            requestTimeoutMillis = 40000
+        }
+    }
+}
+
 suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, user: AuthenticatedUser): T = withContext(Dispatchers.IO) {
     request<T> {
         url(url)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/saker/MineSakerConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/saker/MineSakerConsumer.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.api.saker
 
 import io.ktor.client.*
-import no.nav.personbruker.dittnav.api.config.get
+import no.nav.personbruker.dittnav.api.config.getExtendedTimeout
 import no.nav.personbruker.dittnav.api.saker.ekstern.SisteSakstemaer
 import no.nav.personbruker.dittnav.api.tokenx.AccessToken
 import java.net.URL
@@ -14,7 +14,7 @@ class MineSakerConsumer(
     private val sisteEndredeSakerEndpoint = URL("$mineSakerApiURL/sakstemaer/sistendret")
 
     suspend fun hentSistEndret(user: AccessToken): SisteSakstemaerDTO {
-        val external = client.get<SisteSakstemaer>(sisteEndredeSakerEndpoint, user)
+        val external = client.getExtendedTimeout<SisteSakstemaer>(sisteEndredeSakerEndpoint, user)
         return external.toInternal()
     }
 


### PR DESCRIPTION
Dette gjøres fordi det for en del brukere tar mer enn standardverdien, på 10 sekunder, å hente dataene.

Øker til de samme timeout-verdiene som blir brukt mot Ditt NAV Legacy Api.

Oppretter denne i stor grad for å få kjør e2e-testene.