### PR TITLE
PB-427: Legger til endepunkter som kaller personalia-api i gcp for å hente na…

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/ConsumePersonaliaException.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/ConsumePersonaliaException.kt
@@ -1,0 +1,6 @@
+package no.nav.personbruker.dittnav.api.common
+
+import java.lang.Exception
+
+class ConsumePersonaliaException(message: String, cause: Throwable) : Exception(message, cause)
+

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/common/ExceptionResponseWrapper.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/common/ExceptionResponseWrapper.kt
@@ -17,6 +17,11 @@ suspend fun respondWithError(call: ApplicationCall, log: Logger, exception: Exce
             call.respond(feilkode)
             log.warn("Klarte ikke å hente saker. Returnerer feilkoden '$feilkode' til frontend. $exception", exception)
         }
+        is ConsumePersonaliaException -> {
+            val feilkode = HttpStatusCode.ServiceUnavailable
+            call.respond(feilkode)
+            log.warn("Klarte ikke å hente personalia. Returnerer feilkoden '$feilkode' til frontend. $exception", exception)
+        }
         is ProduceEventException -> {
             val feilkode = HttpStatusCode.ServiceUnavailable
             call.respond(feilkode)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
@@ -22,6 +22,9 @@ import no.nav.personbruker.dittnav.api.loginstatus.LoginLevelService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveConsumer
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveMergerService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveService
+import no.nav.personbruker.dittnav.api.personalia.PersonaliaConsumer
+import no.nav.personbruker.dittnav.api.personalia.PersonaliaService
+import no.nav.personbruker.dittnav.api.personalia.PersonaliaTokendings
 import no.nav.personbruker.dittnav.api.saker.MineSakerConsumer
 import no.nav.personbruker.dittnav.api.saker.MineSakerTokendings
 import no.nav.personbruker.dittnav.api.saker.SakerInnsynUrlResolver
@@ -31,6 +34,7 @@ import no.nav.personbruker.dittnav.api.unleash.UnleashService
 import no.nav.personbruker.dittnav.api.varsel.VarselConsumer
 import no.nav.personbruker.dittnav.api.varsel.VarselService
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
+import java.net.URL
 
 class ApplicationContext {
 
@@ -43,6 +47,7 @@ class ApplicationContext {
 
     val tokendingsService = TokendingsServiceBuilder.buildTokendingsService(maxCachedEntries = 5000)
     val mineSakerTokendings = MineSakerTokendings(tokendingsService, environment.mineSakerApiClientId)
+    val personaliaTokendings = PersonaliaTokendings(tokendingsService, environment.personaliaApiClientId)
 
     val legacyConsumer = LegacyConsumer(httpClient, environment.legacyApiURL)
     val oppgaveConsumer = OppgaveConsumer(httpClient, environment.eventHandlerURL)
@@ -72,6 +77,9 @@ class ApplicationContext {
 
     val beskjedMergerService = BeskjedMergerService(beskjedService, varselService, digiSosService, unleashService)
     val oppgaveMergerService = OppgaveMergerService(oppgaveService, digiSosService, unleashService)
+
+    val personaliaConsumer = PersonaliaConsumer(httpClient, environment.personaliaApiUrl)
+    val personaliaService = PersonaliaService(personaliaConsumer, personaliaTokendings)
 
     private fun createUnleashService(environment: Environment): UnleashService {
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
@@ -18,5 +18,7 @@ data class Environment(
     val digiSosSoknadBaseURL: URL = getEnvVarAsURL("DIGISOS_API_URL", trimTrailingSlash = true),
     val digiSosInnsynBaseURL: URL = getEnvVarAsURL("DIGISOS_INNSYN_API_URL", trimTrailingSlash = true),
     val sakerApiUrl: URL = getEnvVarAsURL("MINE_SAKER_API_URL", trimTrailingSlash = true),
-    val mineSakerApiClientId: String = getEnvVar("MINE_SAKER_API_CLIENT_ID")
+    val mineSakerApiClientId: String = getEnvVar("MINE_SAKER_API_CLIENT_ID"),
+    val personaliaApiUrl: URL = getEnvVarAsURL("PERSONALIA_API_URL"),
+    val personaliaApiClientId: String = getEnvVar("PERSONALIA_API_CLIENT_ID")
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -21,6 +21,7 @@ import no.nav.personbruker.dittnav.api.health.healthApi
 import no.nav.personbruker.dittnav.api.innboks.innboks
 import no.nav.personbruker.dittnav.api.legacy.legacyApi
 import no.nav.personbruker.dittnav.api.oppgave.oppgave
+import no.nav.personbruker.dittnav.api.personalia.personalia
 import no.nav.personbruker.dittnav.api.saker.saker
 import no.nav.personbruker.dittnav.api.unleash.unleash
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
@@ -73,6 +74,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
             innboks(appContext.innboksService)
             brukernotifikasjoner(appContext.brukernotifikasjonService)
             saker(appContext.sakerService)
+            personalia(appContext.personaliaService)
             unleash(appContext.unleashService)
             if(NaisEnvironment.isRunningInDev()) {
                 digiSos(appContext.digiSosService)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaConsumer.kt
@@ -1,0 +1,24 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import io.ktor.client.*
+import no.nav.personbruker.dittnav.api.config.get
+import no.nav.personbruker.dittnav.api.tokenx.AccessToken
+import java.net.URL
+
+class PersonaliaConsumer(
+    private val client: HttpClient,
+    personaliaApiURL: URL
+) {
+
+    private val navnEndpoint = URL("$personaliaApiURL/navn")
+    private val identEndpoint = URL("$personaliaApiURL/ident")
+
+    suspend fun hentNavn(user: AccessToken): PersonaliaNavnDTO {
+        return client.get(navnEndpoint, user)
+    }
+
+    suspend fun hentIdent(user: AccessToken): PersonaliaIdentDTO {
+        return client.get(identEndpoint, user)
+    }
+
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PersonaliaIdentDTO(
+    val ident: String
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTO.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTO.kt
@@ -1,0 +1,8 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class PersonaliaNavnDTO(
+    val navn: String
+)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaService.kt
@@ -1,0 +1,30 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import no.nav.personbruker.dittnav.api.common.ConsumePersonaliaException
+import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
+
+class PersonaliaService (
+    val personaliaConsumer: PersonaliaConsumer,
+    val personaliaTokendings: PersonaliaTokendings
+){
+
+    suspend fun hentNavn(user: AuthenticatedUser): PersonaliaNavnDTO {
+        try {
+            val exchangedToken = personaliaTokendings.exchangeToken(user)
+
+            return personaliaConsumer.hentNavn(exchangedToken)
+        } catch (e: Exception) {
+            throw ConsumePersonaliaException("Klarte ikke å hente navn", e)
+        }
+    }
+
+    suspend fun hentIdent(user: AuthenticatedUser): PersonaliaIdentDTO {
+        try {
+            val exchangedToken = personaliaTokendings.exchangeToken(user)
+
+            return personaliaConsumer.hentIdent(exchangedToken)
+        } catch (e: Exception) {
+            throw ConsumePersonaliaException("Klarte ikke å hente ident", e)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaTokendings.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaTokendings.kt
@@ -1,0 +1,15 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import no.nav.personbruker.dittnav.api.tokenx.AccessToken
+import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
+import no.nav.tms.token.support.tokendings.exchange.TokendingsService
+
+class PersonaliaTokendings(
+    private val tokendingsService: TokendingsService,
+    private val personaliaClientId: String
+) {
+
+    suspend fun exchangeToken(authenticatedUser: AuthenticatedUser): AccessToken {
+        return AccessToken(tokendingsService.exchangeToken(authenticatedUser.token, personaliaClientId))
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/personaliaApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/personaliaApi.kt
@@ -16,7 +16,7 @@ fun Route.personalia(
 ) {
     val log = LoggerFactory.getLogger(PersonaliaService::class.java)
 
-    get("/personalia/navn") {
+    get("/navn") {
         executeOnUnexpiredTokensOnly {
             try {
                 val result = service.hentNavn(authenticatedUser)
@@ -28,7 +28,7 @@ fun Route.personalia(
         }
     }
 
-    get("/personalia/ident") {
+    get("/ident") {
         executeOnUnexpiredTokensOnly {
             try {
                 val result = service.hentIdent(authenticatedUser)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/personaliaApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/personalia/personaliaApi.kt
@@ -1,0 +1,44 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import no.nav.personbruker.dittnav.api.common.respondWithError
+import no.nav.personbruker.dittnav.api.config.authenticatedUser
+import no.nav.personbruker.dittnav.api.config.executeOnUnexpiredTokensOnly
+import no.nav.personbruker.dittnav.api.digisos.DigiSosService
+import no.nav.personbruker.dittnav.common.logging.util.logger
+import org.slf4j.LoggerFactory
+
+fun Route.personalia(
+    service: PersonaliaService
+) {
+    val log = LoggerFactory.getLogger(PersonaliaService::class.java)
+
+    get("/personalia/navn") {
+        executeOnUnexpiredTokensOnly {
+            try {
+                val result = service.hentNavn(authenticatedUser)
+                call.respond(HttpStatusCode.OK, result)
+
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
+        }
+    }
+
+    get("/personalia/ident") {
+        executeOnUnexpiredTokensOnly {
+            try {
+                val result = service.hentIdent(authenticatedUser)
+                call.respond(HttpStatusCode.OK, result)
+
+            } catch (exception: Exception) {
+                respondWithError(call, log, exception)
+            }
+        }
+    }
+
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTOTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTOTest.kt
@@ -16,7 +16,6 @@ internal class PersonaliaIdentDTOTest {
     @Test
     fun `Skal kunne deserialisere responsen fra mine saker`() {
         val objectMapper = json()
-
         val deserialized = objectMapper.decodeFromString<PersonaliaIdentDTO>(response)
 
         deserialized.shouldNotBeNull()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTOTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaIdentDTOTest.kt
@@ -1,0 +1,25 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import kotlinx.serialization.decodeFromString
+import no.nav.personbruker.dittnav.api.config.json
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+internal class PersonaliaIdentDTOTest {
+
+    private val response = """
+        {
+          "ident": "1234"
+        }
+    """.trimIndent()
+
+    @Test
+    fun `Skal kunne deserialisere responsen fra mine saker`() {
+        val objectMapper = json()
+
+        val deserialized = objectMapper.decodeFromString<PersonaliaIdentDTO>(response)
+
+        deserialized.shouldNotBeNull()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTOTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTOTest.kt
@@ -16,7 +16,6 @@ internal class PersonaliaNavnDTOTest {
     @Test
     fun `Skal kunne deserialisere responsen fra mine saker`() {
         val objectMapper = json()
-
         val deserialized = objectMapper.decodeFromString<PersonaliaNavnDTO>(response)
 
         deserialized.shouldNotBeNull()

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTOTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaNavnDTOTest.kt
@@ -1,0 +1,25 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import kotlinx.serialization.decodeFromString
+import no.nav.personbruker.dittnav.api.config.json
+import org.amshove.kluent.shouldNotBeNull
+import org.junit.jupiter.api.Test
+
+internal class PersonaliaNavnDTOTest {
+
+    private val response = """
+        {
+          "navn": "TestName"
+        }
+    """.trimIndent()
+
+    @Test
+    fun `Skal kunne deserialisere responsen fra mine saker`() {
+        val objectMapper = json()
+
+        val deserialized = objectMapper.decodeFromString<PersonaliaNavnDTO>(response)
+
+        deserialized.shouldNotBeNull()
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaObjectMother.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaObjectMother.kt
@@ -1,0 +1,13 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+object PersonaliaObjectMother {
+
+    fun giveMeNavn(): PersonaliaNavnDTO {
+        return PersonaliaNavnDTO("TestName")
+    }
+
+    fun giveMeIdent(): PersonaliaIdentDTO {
+        return PersonaliaIdentDTO("1234")
+    }
+
+}

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/personalia/PersonaliaServiceTest.kt
@@ -1,0 +1,102 @@
+package no.nav.personbruker.dittnav.api.personalia
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import no.nav.personbruker.dittnav.api.common.AuthenticatedUserObjectMother
+import no.nav.personbruker.dittnav.api.common.ConsumePersonaliaException
+import no.nav.personbruker.dittnav.api.tokenx.AccessToken
+import org.amshove.kluent.*
+import org.junit.jupiter.api.Test
+
+internal class PersonaliaServiceTest {
+    private val personaliaConsumer = mockk<PersonaliaConsumer>(relaxed = true)
+    private val tokendings = mockk<PersonaliaTokendings>()
+    private val dummyUser = AuthenticatedUserObjectMother.createAuthenticatedUser()
+    private val dummyAccessToken = AccessToken("123")
+
+    init {
+        coEvery { tokendings.exchangeToken(any()) } returns dummyAccessToken
+    }
+
+    @Test
+    fun `Skal hente navn fra personalia api`() {
+        coEvery { personaliaConsumer.hentNavn(any()) } returns PersonaliaObjectMother.giveMeNavn()
+
+        val service = PersonaliaService(personaliaConsumer, tokendings)
+
+        val result = runBlocking {
+            service.hentNavn(dummyUser)
+        }
+
+        coVerify(exactly = 1) { tokendings.exchangeToken(any()) }
+        coVerify(exactly = 1) { personaliaConsumer.hentNavn(any()) }
+
+        confirmVerified(tokendings)
+        confirmVerified(personaliaConsumer)
+
+        result.shouldNotBeNull()
+        result.navn `should be` "TestName"
+    }
+
+    @Test
+    fun `Skal fange og kaste feil videre hvis henting av navn feiler`() {
+        coEvery { personaliaConsumer.hentNavn(any()) } throws IllegalArgumentException("Simulert feil i en test")
+
+        val service = PersonaliaService(personaliaConsumer, tokendings)
+
+        val result = runCatching {
+            runBlocking {
+                service.hentNavn(dummyUser)
+            }
+
+        }
+
+        result.isFailure `should be equal to` true
+        val exception = result.exceptionOrNull()
+        exception `should be instance of` ConsumePersonaliaException::class
+        exception?.cause `should be instance of` IllegalArgumentException::class
+    }
+
+    @Test
+    fun `Skal hente ident fra personalia api`() {
+        coEvery { personaliaConsumer.hentIdent(any()) } returns PersonaliaObjectMother.giveMeIdent()
+
+        val service = PersonaliaService(personaliaConsumer, tokendings)
+
+        val result = runBlocking {
+            service.hentIdent(dummyUser)
+        }
+
+        coVerify(exactly = 1) { tokendings.exchangeToken(any()) }
+        coVerify(exactly = 1) { personaliaConsumer.hentIdent(any()) }
+
+        confirmVerified(tokendings)
+        confirmVerified(personaliaConsumer)
+
+        result.shouldNotBeNull()
+        result.ident `should be` "1234"
+    }
+
+    @Test
+    fun `Skal fange og kaste feil videre hvis henting av ident feiler`() {
+        coEvery { personaliaConsumer.hentIdent(any()) } throws IllegalArgumentException("Simulert feil i en test")
+
+        val service = PersonaliaService(personaliaConsumer, tokendings)
+
+        val result = runCatching {
+            runBlocking {
+                service.hentIdent(dummyUser)
+            }
+
+        }
+
+        result.isFailure `should be equal to` true
+        val exception = result.exceptionOrNull()
+        exception `should be instance of` ConsumePersonaliaException::class
+        exception?.cause `should be instance of` IllegalArgumentException::class
+    }
+
+}


### PR DESCRIPTION
…vn og ident.

Dette gjøres for å fase ut bruken av dittnav-legacy-api og tps-proxy.
