### PR TITLE
PB-927: Unleash

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedMergerService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedMergerService.kt
@@ -33,7 +33,7 @@ class BeskjedMergerService(
     }
 
     private suspend fun fetchActiveFromDigiSosIfEnabled(user: AuthenticatedUser) =
-        if (unleashService.digiSosEnabled(user)) {
+        if (unleashService.digiSosPaabegynteEnabled(user)) {
             digiSosService.getPaabegynteActive(user)
         } else {
             MultiSourceResult.createEmptyResult()
@@ -64,7 +64,7 @@ class BeskjedMergerService(
     }
 
     private suspend fun fetchInactiveFromDigiSosIfEnabled(user: AuthenticatedUser) =
-        if (unleashService.digiSosEnabled(user)) {
+        if (unleashService.digiSosPaabegynteEnabled(user)) {
             digiSosService.getPaabegynteInactive(user)
         } else {
             MultiSourceResult.createEmptyResult()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
@@ -34,7 +34,6 @@ import no.nav.personbruker.dittnav.api.unleash.UnleashService
 import no.nav.personbruker.dittnav.api.varsel.VarselConsumer
 import no.nav.personbruker.dittnav.api.varsel.VarselService
 import no.nav.tms.token.support.tokendings.exchange.TokendingsServiceBuilder
-import java.net.URL
 
 class ApplicationContext {
 
@@ -116,9 +115,9 @@ class ApplicationContext {
                 disable(UnleashService.varselinnboksToggleName)
             }
             if (environment.fakeUnleashIncludeDigiSos) {
-                enable(UnleashService.digiSosToggleName)
+                enable(UnleashService.digiSosOppgaveToggleName)
             } else {
-                disable(UnleashService.digiSosToggleName)
+                disable(UnleashService.digiSosOppgaveToggleName)
             }
             if (environment.fakeUnleashIncludeMineSaker) {
                 enable(UnleashService.brukMineSakerToggleName)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/digisos/Paabegynte.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/digisos/Paabegynte.kt
@@ -15,5 +15,5 @@ data class Paabegynte(
     val link: String,
     val sikkerhetsnivaa: Int,
     val sistOppdatert: LocalDateTime,
-    val aktiv : Boolean
+    val isAktiv : Boolean
 )

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/digisos/beskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/digisos/beskjedTransformer.kt
@@ -20,7 +20,7 @@ fun Paabegynte.toInternal() = BeskjedDTO(
     produsent = "digiSos",
     sistOppdatert = sistOppdatert.toZonedDateTime(),
     sikkerhetsnivaa = 3,
-    aktiv = aktiv,
+    aktiv = isAktiv,
     grupperingsId = grupperingsId
 )
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveMergerService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveMergerService.kt
@@ -28,7 +28,7 @@ class OppgaveMergerService(
     }
 
     private suspend fun fetchActiveFromDigiSosIfEnabled(user: AuthenticatedUser) =
-        if (unleashService.digiSosEnabled(user)) {
+        if (unleashService.digiSosOppgaveEnabled(user)) {
             digiSosService.getEttersendelseActive(user)
         } else {
             MultiSourceResult.createEmptyResult()
@@ -47,7 +47,7 @@ class OppgaveMergerService(
     }
 
     private suspend fun fetchInactiveFromDigiSosIfEnabled(user: AuthenticatedUser) : MultiSourceResult<OppgaveDTO, KildeType> {
-        return if (unleashService.digiSosEnabled(user)) {
+        return if (unleashService.digiSosOppgaveEnabled(user)) {
             digiSosService.getEttersendelseInactive(user)
         } else {
             MultiSourceResult.createEmptyResult()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/unleash/UnleashService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/unleash/UnleashService.kt
@@ -9,7 +9,8 @@ import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
 class UnleashService(private val unleashClient: Unleash) {
 
     companion object {
-        const val digiSosToggleName: String = "digiSosEnabled"
+        const val digiSosOppgaveToggleName: String = "digiSosEnabled"
+        const val digisosPaabegynteToggleName: String = "digisosPaabegynteEnabled"
         const val varselinnboksToggleName: String = "mergeBeskjedVarselEnabled"
         const val brukMineSakerToggleName: String = "dittnav.brukMineSaker"
         const val situasjonToggleName: String = "veientilarbeid.kanViseUtfraSituasjon"
@@ -21,8 +22,12 @@ class UnleashService(private val unleashClient: Unleash) {
         }
     }
 
-    suspend fun digiSosEnabled(user: AuthenticatedUser): Boolean = withContext(Dispatchers.IO) {
-        unleashClient.isEnabled(digiSosToggleName, createUnleashContext(user), false)
+    suspend fun digiSosOppgaveEnabled(user: AuthenticatedUser): Boolean = withContext(Dispatchers.IO) {
+        unleashClient.isEnabled(digiSosOppgaveToggleName, createUnleashContext(user), false)
+    }
+
+    suspend fun digiSosPaabegynteEnabled(user: AuthenticatedUser): Boolean = withContext(Dispatchers.IO) {
+        unleashClient.isEnabled(digisosPaabegynteToggleName, createUnleashContext(user), false)
     }
 
     suspend fun mineSakerEnabled(user: AuthenticatedUser): Boolean = withContext(Dispatchers.IO) {

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedMergerServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/beskjed/BeskjedMergerServiceTest.kt
@@ -102,9 +102,9 @@ internal class BeskjedMergerServiceTest {
     }
 
     @Test
-    fun `Hent aktive fra DigiSos hvis aktivert`() {
+    fun `Hent påbegynte søknader fra DigiSos hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digisosPaabegynteToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -130,7 +130,7 @@ internal class BeskjedMergerServiceTest {
     fun `Hent aktive fra alle kilder hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
             enable(UnleashService.varselinnboksToggleName)
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digisosPaabegynteToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -203,7 +203,7 @@ internal class BeskjedMergerServiceTest {
     @Test
     fun `Hent inaktive fra DigiSos hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digisosPaabegynteToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -229,7 +229,7 @@ internal class BeskjedMergerServiceTest {
     fun `Hent inaktive fra alle kilder hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
             enable(UnleashService.varselinnboksToggleName)
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digisosPaabegynteToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
         val beskjedMerger = BeskjedMergerService(beskjedService, varselService, digiSosService, unleashService)

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/digisos/BeskjedDtoTransformerTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/digisos/BeskjedDtoTransformerTest.kt
@@ -17,7 +17,7 @@ internal class BeskjedDtoTransformerTest {
         internal.grupperingsId `should be equal to` external.grupperingsId
         internal.tekst `should be equal to` external.tekst
         internal.link `should be equal to` external.link
-        internal.aktiv `should be equal to` external.aktiv
+        internal.aktiv `should be equal to` external.isAktiv
         internal.sistOppdatert `should be equal to` external.sistOppdatert.toZonedDateTime()
         internal.produsent `should be equal to` "digiSos"
         internal.uid `should be equal to` external.eventId

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/digisos/PaabegynteTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/digisos/PaabegynteTest.kt
@@ -16,7 +16,7 @@ internal class PaabegynteTest {
         "link": "https://dummy/enId",
         "sikkerhetsnivaa": 3,
         "sistOppdatert": "2021-07-01T09:32:35.416856",
-        "aktiv": false
+        "isAktiv": false
     }""".trimIndent()
 
     @Test

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveMergerServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/oppgave/OppgaveMergerServiceTest.kt
@@ -65,9 +65,9 @@ internal class OppgaveMergerServiceTest {
     }
 
     @Test
-    fun `Hent aktive fra DigiSos hvis aktivert`() {
+    fun `Hent ettersendelser fra DigiSos hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digiSosOppgaveToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -91,7 +91,7 @@ internal class OppgaveMergerServiceTest {
     fun `Hent aktive fra alle kilder hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
             enable(UnleashService.varselinnboksToggleName)
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digiSosOppgaveToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -135,7 +135,7 @@ internal class OppgaveMergerServiceTest {
     @Test
     fun `Hent inaktive fra DigiSos hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digiSosOppgaveToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
 
@@ -159,7 +159,7 @@ internal class OppgaveMergerServiceTest {
     fun `Hent inaktive fra alle kilder hvis aktivert`() {
         val fakeUnleash = FakeUnleash().apply {
             enable(UnleashService.varselinnboksToggleName)
-            enable(UnleashService.digiSosToggleName)
+            enable(UnleashService.digiSosOppgaveToggleName)
         }
         val unleashService = UnleashService(fakeUnleash)
         val oppgaveMerger = OppgaveMergerService(oppgaveService, digiSosService, unleashService)


### PR DESCRIPTION
Splittet unleash toggelen digisosEnabled i to, slik at henting av påbegynte søknader i digisos nå ligger under en egen unleash toggel som heter digisosPaabegynteEnabled.