### PR TITLE
Senker reserverte resurser basert på metrikker for reell bruk.

### DIFF
--- a/nais/dev-sbs/nais.yaml
+++ b/nais/dev-sbs/nais.yaml
@@ -43,5 +43,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "100m"
       memory: 580Mi

--- a/nais/prod-sbs/nais.yaml
+++ b/nais/prod-sbs/nais.yaml
@@ -43,5 +43,5 @@ spec:
       cpu: "3"
       memory: 768Mi
     requests:
-      cpu: "500m"
+      cpu: "100m"
       memory: 580Mi


### PR DESCRIPTION
Senker reservert cpu til 100m for å bedre matche reell bruk, som gjerne svinger mellom 10m om natten og 250m ved peak.