### PR TITLE
Tokenx header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.logback)
-    implementation(Tms.KtorTokenSupport.tokendingsExchange)
+    implementation("com.github.navikt.tms-ktor-token-support:token-support-tokendings-exchange:2022.01.27-fix-header-2")
     implementation(Unleash.clientJava)
 
     testImplementation(Junit.api)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     implementation(Prometheus.common)
     implementation(Prometheus.hotspot)
     implementation(Prometheus.logback)
-    implementation("com.github.navikt.tms-ktor-token-support:token-support-tokendings-exchange:2022.01.27-fix-header-2")
+    implementation("com.github.navikt.tms-ktor-token-support:token-support-tokendings-exchange:2022.01.27-13.11-a6b55dd90347")
     implementation(Unleash.clientJava)
 
     testImplementation(Junit.api)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import no.nav.personbruker.dittnav.api.tokenx.AccessToken
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
+import no.nav.tms.token.support.tokendings.exchange.TokenXHeader
 import java.net.URL
 
 suspend inline fun <reified T> HttpClient.get(url: URL, user: AuthenticatedUser): T = withContext(Dispatchers.IO) {
@@ -32,6 +33,19 @@ suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, accessTok
         url(url)
         method = HttpMethod.Get
         header(HttpHeaders.Authorization, "Bearer ${accessToken.value}")
+        timeout {
+            socketTimeoutMillis = 30000
+            connectTimeoutMillis = 10000
+            requestTimeoutMillis = 40000
+        }
+    }
+}
+
+suspend inline fun <reified T> HttpClient.getWithTokenx(url: URL, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
+    request<T> {
+        url(url)
+        method = HttpMethod.Get
+        header(TokenXHeader.Authorization, "Bearer ${accessToken.value}")
         timeout {
             socketTimeoutMillis = 30000
             connectTimeoutMillis = 10000

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/saker/MineSakerConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/saker/MineSakerConsumer.kt
@@ -1,7 +1,7 @@
 package no.nav.personbruker.dittnav.api.saker
 
 import io.ktor.client.*
-import no.nav.personbruker.dittnav.api.config.getExtendedTimeout
+import no.nav.personbruker.dittnav.api.config.getWithTokenx
 import no.nav.personbruker.dittnav.api.saker.ekstern.SisteSakstemaer
 import no.nav.personbruker.dittnav.api.tokenx.AccessToken
 import java.net.URL
@@ -14,7 +14,7 @@ class MineSakerConsumer(
     private val sisteEndredeSakerEndpoint = URL("$mineSakerApiURL/sakstemaer/sistendret")
 
     suspend fun hentSistEndret(user: AccessToken): SisteSakstemaerDTO {
-        val external = client.getExtendedTimeout<SisteSakstemaer>(sisteEndredeSakerEndpoint, user)
+        val external = client.getWithTokenx<SisteSakstemaer>(sisteEndredeSakerEndpoint, user)
         return external.toInternal()
     }
 


### PR DESCRIPTION
Bruk egen tokenx authorization header for å unngå at idporten-sidecar overskriver tokenx-token.