### PR TITLE
Legger til options i CORS config.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -40,6 +40,7 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         host(appContext.environment.corsAllowedOrigins, schemes = listOf(appContext.environment.corsAllowedSchemes))
         allowCredentials = true
         header(HttpHeaders.ContentType)
+        method(HttpMethod.Options)
     }
 
     val config = this.environment.config


### PR DESCRIPTION
Når frontend og backend ligger på forskjellige domener blir det sendt et OPTIONS-preflight kall før vi sender POST. Dette preflight-kallet får 403 ettersom bare GET, POST og HEAD er godkjent som default i ktor. 

Fikser ved å eksplisitt godkjenne OPTIONS-kall.