### PR TITLE
Legger til rette for å kunne tillate custom headers i cors.

### DIFF
--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.api.config
 
 import no.nav.personbruker.dittnav.common.util.config.BooleanEnvVar.getEnvVarAsBoolean
 import no.nav.personbruker.dittnav.common.util.config.StringEnvVar.getEnvVar
+import no.nav.personbruker.dittnav.common.util.config.StringEnvVar.getEnvVarAsList
 import no.nav.personbruker.dittnav.common.util.config.UrlEnvVar.getEnvVarAsURL
 import java.net.URL
 
@@ -9,6 +10,7 @@ data class Environment(
     val eventHandlerURL: URL = getEnvVarAsURL("EVENT_HANDLER_URL", trimTrailingSlash = true),
     val corsAllowedOrigins: String = getEnvVar("CORS_ALLOWED_ORIGINS"),
     val corsAllowedSchemes: String = getEnvVar("CORS_ALLOWED_SCHEMES", "https"),
+    val corsAllowedHeaders: List<String> = getEnvVarAsList("CORS_ALLOWED_HEADERS"),
     val fakeUnleashIncludeVarsel: Boolean = getEnvVarAsBoolean("FAKE_UNLEASH_INCLUDE_VARSEL", false),
     val fakeUnleashIncludeDigiSos: Boolean = getEnvVarAsBoolean("FAKE_UNLEASH_INCLUDE_DIGISOS", false),
     val unleashApiUrl: String = getEnvVar("UNLEASH_API_URL"),

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/bootstrap.kt
@@ -43,7 +43,9 @@ fun Application.mainModule(appContext: ApplicationContext = ApplicationContext()
         host(appContext.environment.corsAllowedOrigins, schemes = listOf(appContext.environment.corsAllowedSchemes))
         allowCredentials = true
         header(HttpHeaders.ContentType)
-        method(HttpMethod.Options)
+        appContext.environment.corsAllowedHeaders.forEach { approvedHeader ->
+            header(approvedHeader)
+        }
     }
 
     val config = this.environment.config


### PR DESCRIPTION
Legger opp til å godkjenne "adrum" i cors-config, slik at vi ikke får stopp når vi prøver å arkivere beskjed-eventer fra forsiden.