### PR TITLE
Tokenx mot meldekort

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -38,7 +38,7 @@ spec:
         - application: tms-personalia-api
         - application: pto-proxy
           namespace: pto
-        - application: meldekort-api
+        - application: meldekort-api-q1
           namespace: meldekort
   ingresses:
     - "https://person.dev.nav.no/dittnav-api"

--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -38,6 +38,8 @@ spec:
         - application: tms-personalia-api
         - application: pto-proxy
           namespace: pto
+        - application: meldekort-api
+          namespace: meldekort
   ingresses:
     - "https://person.dev.nav.no/dittnav-api"
   resources:

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -37,6 +37,8 @@ spec:
         - application: tms-personalia-api
         - application: pto-proxy
           namespace: pto
+        - application: meldekort-api
+          namespace: meldekort
   ingresses:
     - "https://person.nav.no/dittnav-api"
   resources:

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/ApplicationContext.kt
@@ -17,6 +17,7 @@ import no.nav.personbruker.dittnav.api.innboks.InnboksConsumer
 import no.nav.personbruker.dittnav.api.innboks.InnboksService
 import no.nav.personbruker.dittnav.api.meldekort.MeldekortConsumer
 import no.nav.personbruker.dittnav.api.meldekort.MeldekortService
+import no.nav.personbruker.dittnav.api.meldekort.MeldekortTokendings
 import no.nav.personbruker.dittnav.api.oppfolging.OppfolgingConsumer
 import no.nav.personbruker.dittnav.api.oppfolging.OppfolgingService
 import no.nav.personbruker.dittnav.api.oppgave.OppgaveConsumer
@@ -68,7 +69,8 @@ class ApplicationContext {
     val personaliaService = PersonaliaService(personaliaConsumer, personaliaTokendings)
 
     val meldekortConsumer = MeldekortConsumer(httpClient, environment.meldekortApiUrl)
-    val meldekortService = MeldekortService(meldekortConsumer)
+    val meldekortTokendings = MeldekortTokendings(tokendingsService, environment.meldekortClientId)
+    val meldekortService = MeldekortService(meldekortConsumer, meldekortTokendings)
 
     val oppfolgingConsumer = OppfolgingConsumer(httpClientIgnoreUnknownKeys, environment.oppfolgingApiUrl)
     val oppfolgingService = OppfolgingService(oppfolgingConsumer)

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
@@ -22,6 +22,7 @@ data class Environment(
     val personaliaApiClientId: String = getEnvVar("PERSONALIA_API_CLIENT_ID"),
     val eventhandlerClientId: String = getEnvVar("EVENTHANDLER_CLIENT_ID"),
     val meldekortApiUrl: URL = getEnvVarAsURL("MELDEKORT_API_URL"),
+    val meldekortClientId: String = getEnvVar("MELDEKORT_CLIENT_UD"),
     val oppfolgingApiUrl: URL = getEnvVarAsURL("OPPFOLGING_API_URL"),
     val innloggingsinfoUrl: URL = getEnvVarAsURL("INNLOGGINGSINFO_URL"),
     val isRunningInDev: Boolean = isRunningInDev()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/Environment.kt
@@ -22,7 +22,7 @@ data class Environment(
     val personaliaApiClientId: String = getEnvVar("PERSONALIA_API_CLIENT_ID"),
     val eventhandlerClientId: String = getEnvVar("EVENTHANDLER_CLIENT_ID"),
     val meldekortApiUrl: URL = getEnvVarAsURL("MELDEKORT_API_URL"),
-    val meldekortClientId: String = getEnvVar("MELDEKORT_CLIENT_UD"),
+    val meldekortClientId: String = getEnvVar("MELDEKORT_CLIENT_ID"),
     val oppfolgingApiUrl: URL = getEnvVarAsURL("OPPFOLGING_API_URL"),
     val innloggingsinfoUrl: URL = getEnvVarAsURL("INNLOGGINGSINFO_URL"),
     val isRunningInDev: Boolean = isRunningInDev()

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -57,7 +57,7 @@ suspend inline fun <reified T> HttpClient.getWithMeldekortTokenx(url: URL, acces
     request {
         url(url)
         method = HttpMethod.Get
-        header("TokeXAuthorization", "Bearer ${accessToken.value}")
+        header("TokenXAuthorization", "Bearer ${accessToken.value}")
         timeout {
             socketTimeoutMillis = 30000
             connectTimeoutMillis = 10000

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/config/httpClient.kt
@@ -53,11 +53,11 @@ suspend inline fun <reified T> HttpClient.getWithTokenx(url: URL, accessToken: A
     }
 }
 
-suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, user: AuthenticatedUser): T = withContext(Dispatchers.IO) {
+suspend inline fun <reified T> HttpClient.getWithMeldekortTokenx(url: URL, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
     request {
         url(url)
         method = HttpMethod.Get
-        header(HttpHeaders.Authorization, user.createAuthenticationHeader())
+        header("TokeXAuthorization", "Bearer ${accessToken.value}")
         timeout {
             socketTimeoutMillis = 30000
             connectTimeoutMillis = 10000
@@ -66,17 +66,6 @@ suspend inline fun <reified T> HttpClient.getExtendedTimeout(url: URL, user: Aut
     }
 }
 
-suspend inline fun <reified T> HttpClient.getWithEssoTokenHeader(url: URL, user: AuthenticatedUser): T = withContext(Dispatchers.IO) {
-    require(user.auxiliaryEssoToken != null) {
-        "Prøvde å sette esso-token som header, men fant det ikke for innlogget bruker."
-    }
-    request {
-        url(url)
-        method = HttpMethod.Get
-        header(HttpHeaders.Authorization, user.createAuthenticationHeader())
-        header("nav-esso", user.auxiliaryEssoToken)
-    }
-}
 
 suspend inline fun <reified T> HttpClient.post(url: URL, done: DoneDTO, accessToken: AccessToken): T = withContext(Dispatchers.IO) {
     post {

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortConsumer.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortConsumer.kt
@@ -2,6 +2,7 @@ package no.nav.personbruker.dittnav.api.meldekort
 
 import io.ktor.client.*
 import no.nav.personbruker.dittnav.api.config.get
+import no.nav.personbruker.dittnav.api.config.getWithMeldekortTokenx
 import no.nav.personbruker.dittnav.api.meldekort.external.MeldekortstatusExternal
 import no.nav.personbruker.dittnav.api.tokenx.AccessToken
 import java.net.URL
@@ -14,6 +15,6 @@ class MeldekortConsumer(
     private val meldekortStatusEndpoint = URL("$meldekortApiBaseURL/api/person/meldekortstatus")
 
     suspend fun getMeldekortStatus(accessToken: AccessToken): MeldekortstatusExternal {
-        return client.get(meldekortStatusEndpoint, accessToken)
+        return client.getWithMeldekortTokenx(meldekortStatusEndpoint, accessToken)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortService.kt
@@ -1,5 +1,6 @@
 package no.nav.personbruker.dittnav.api.meldekort
 
+import no.nav.personbruker.dittnav.api.meldekort.external.MeldekortstatusExternal
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
 
 class MeldekortService(
@@ -13,5 +14,11 @@ class MeldekortService(
         val meldekortStatus = meldekortConsumer.getMeldekortStatus(token)
 
         return MeldekortTransformer.toInternal(meldekortStatus)
+    }
+
+    suspend fun getMeldekortStatus(user: AuthenticatedUser): MeldekortstatusExternal {
+        val token = meldekortTokendings.exchangeToken(user)
+
+        return meldekortConsumer.getMeldekortStatus(token)
     }
 }

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortService.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortService.kt
@@ -1,12 +1,14 @@
 package no.nav.personbruker.dittnav.api.meldekort
 
-import no.nav.personbruker.dittnav.api.tokenx.AccessToken
 import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
 
-class MeldekortService(private val meldekortConsumer: MeldekortConsumer) {
+class MeldekortService(
+    private val meldekortConsumer: MeldekortConsumer,
+    private val meldekortTokendings: MeldekortTokendings
+) {
 
     suspend fun getMeldekortInfo(user: AuthenticatedUser): Meldekortinfo {
-        val token = AccessToken(user.token)
+        val token = meldekortTokendings.exchangeToken(user)
 
         val meldekortStatus = meldekortConsumer.getMeldekortStatus(token)
 

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortTokendings.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortTokendings.kt
@@ -1,0 +1,15 @@
+package no.nav.personbruker.dittnav.api.meldekort
+
+import no.nav.personbruker.dittnav.api.tokenx.AccessToken
+import no.nav.personbruker.dittnav.common.security.AuthenticatedUser
+import no.nav.tms.token.support.tokendings.exchange.TokendingsService
+
+class MeldekortTokendings(
+    private val tokendingsService: TokendingsService,
+    private val meldekortClientId: String
+) {
+
+    suspend fun exchangeToken(authenticatedUser: AuthenticatedUser): AccessToken {
+        return AccessToken(tokendingsService.exchangeToken(authenticatedUser.token, meldekortClientId))
+    }
+}

--- a/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/meldekortApi.kt
+++ b/src/main/kotlin/no/nav/personbruker/dittnav/api/meldekort/meldekortApi.kt
@@ -21,4 +21,15 @@ fun Route.meldekortApi(meldekortService: MeldekortService) {
             call.respond(HttpStatusCode.InternalServerError)
         }
     }
+
+    get("/meldekortstatus") {
+        try {
+            val meldekortStatus = meldekortService.getMeldekortStatus(authenticatedUser)
+
+            call.respond(meldekortStatus)
+        } catch (e: Exception) {
+            log.warn("Det skjedde en feil mot meldekort. Feilmelding: [${e.message}]. $authenticatedUser", e)
+            call.respond(HttpStatusCode.InternalServerError)
+        }
+    }
 }

--- a/src/test/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortServiceTest.kt
+++ b/src/test/kotlin/no/nav/personbruker/dittnav/api/meldekort/MeldekortServiceTest.kt
@@ -13,16 +13,22 @@ import org.junit.jupiter.api.Test
 internal class MeldekortServiceTest {
 
     private val consumer: MeldekortConsumer = mockk()
-    private val meldekortService = MeldekortService(consumer)
+    private val tokendings: MeldekortTokendings = mockk()
+    private val meldekortService = MeldekortService(consumer, tokendings)
 
     private val user = AuthenticatedUserObjectMother.createAuthenticatedUser("123")
+    private val token = AccessToken(user.token)
 
     @Test
     fun `should fetch and transform external meldekortstatus`() {
         val externalMeldekortStatus = MeldekortExternalObjectMother.createMeldekortStatus()
 
         coEvery {
-            consumer.getMeldekortStatus(AccessToken(user.token))
+            tokendings.exchangeToken(user)
+        } returns token
+
+        coEvery {
+            consumer.getMeldekortStatus(token)
         } returns externalMeldekortStatus
 
         val result = runBlocking {


### PR DESCRIPTION
Legger på tokenx i kall mot meldekort. 

Lagt til et ekstra endepunkt `/meldekortstatus`, som i teorien skal levere data på et format veientilarbeid godtar. Dette er kun ment som en fallback for dem, dersom de ikke er klare innen onsdag, og kan fjernes dersom de har klar en løsning.

Accesspolicies og miljøvariabler skal være klare for prod. 